### PR TITLE
implement polling based auto refresh for TaskCommandList and TaskComm…

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "scripts": {
     "start": "react-app-rewired start",
-    "start-untyped": "TS_CHECKS=false npm start",
+    "start-untyped": "TS_CHECKS=\"false\" react-app-rewired start",
     "build": "react-app-rewired build",
     "relay": "npx relay-compiler --verbose --watchman false --src ./src --schema schema.graphql --language typescript",
     "sync-schema": "get-graphql-schema https://api.cirrus-ci.com/schema.json > schema.graphql",

--- a/src/components/BuildDetails.tsx
+++ b/src/components/BuildDetails.tsx
@@ -21,6 +21,7 @@ import CirrusFavicon from './CirrusFavicon';
 import NotificationList from './NotificationList';
 import TaskList from './TaskList';
 import { BuildDetails_build } from './__generated__/BuildDetails_build.graphql';
+import { isBuildFinalStatus } from '../utils/status';
 
 const buildApproveMutation = graphql`
   mutation BuildDetailsApproveBuildMutation($input: BuildApproveInput!) {
@@ -100,10 +101,12 @@ class BuildDetails extends React.Component<Props> {
   componentDidMount() {
     let variables = { buildID: this.props.build.id };
 
-    this.subscription = requestSubscription(environment, {
-      subscription: buildSubscription,
-      variables: variables,
-    });
+    if (!isBuildFinalStatus(this.props.build.status)) {
+      this.subscription = requestSubscription(environment, {
+        subscription: buildSubscription,
+        variables: variables,
+      });
+    }
   }
 
   componentWillUnmount() {

--- a/src/components/DurationTicker.tsx
+++ b/src/components/DurationTicker.tsx
@@ -2,14 +2,39 @@ import React from 'react';
 import { formatDuration } from '../utils/time';
 
 interface Props {
-  timestamp: number;
+  startTimestamp: number;
 }
 
-class DurationTicker extends React.Component<Props> {
+interface State {
+  currentTimestamp: number;
+}
+
+class DurationTicker extends React.Component<Props, State> {
+  secondsTicker: NodeJS.Timeout;
+
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      currentTimestamp: Date.now(),
+    };
+  }
+
+  componentDidMount() {
+    clearInterval(this.secondsTicker);
+    // we just need 1-second precision and only want to rerender once per second
+    this.secondsTicker = setInterval(() => {
+      this.setState({
+        currentTimestamp: Date.now(),
+      });
+    }, 1000);
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.secondsTicker);
+  }
+
   render() {
-    let durationInSeconds = (Date.now() - this.props.timestamp) / 1000;
-    setTimeout(() => this.forceUpdate(), 1000);
-    return <span>{formatDuration(durationInSeconds)}</span>;
+    return <span>{formatDuration((this.state.currentTimestamp - this.props.startTimestamp) / 1000)}</span>;
   }
 }
 

--- a/src/components/TaskCommandList.tsx
+++ b/src/components/TaskCommandList.tsx
@@ -72,7 +72,7 @@ class TaskCommandList extends React.Component<Props> {
               {finished ? (
                 formatDuration(command.durationInSeconds)
               ) : isTaskCommandExecuting(command.status) ? (
-                <DurationTicker timestamp={commandStartTimestamp} />
+                <DurationTicker startTimestamp={commandStartTimestamp} />
               ) : (
                 ''
               )}

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,6 +1,6 @@
 import pluralize from 'pluralize';
 
-export function formatDuration(durationInSeconds) {
+export function formatDuration(durationInSeconds: number) {
   if (durationInSeconds >= 24 * 60 * 60) {
     let hours = durationInSeconds / 60 / 60;
     return Math.round(hours) + 'h';


### PR DESCRIPTION
…andLogs

This PR implements a temporary polling based workaround to get sense of "realtime" updates in the TaskCommandList and TaskCommandLogs view.
The polling logic can be removed once the websocket / subscription based updates work reliably.

Besides that this PR:
- Implements auto-expanding logs (when command is executing) similar to what was proposed by @RDIL in #87
- Fixes a small problem in DurationTicket which printed memory leak warnings / errors in the console due to uncleared `setTimeout` (also, using forceUpdate inside a .render function was kinda weird 😄 ).
