### PR TITLE
Change icon for cirrus-ci-web repository link

### DIFF
--- a/serve.json
+++ b/serve.json
@@ -33,15 +33,6 @@
           "value": "public,max-age=604800"
         }
       ]
-    },
-    {
-      "source": "/manifest.json",
-      "headers": [
-        {
-          "key": "Access-Control-Allow-Origin",
-          "value": "*"
-        }
-      ]
     }
   ]
 }

--- a/serve.json
+++ b/serve.json
@@ -33,6 +33,15 @@
           "value": "public,max-age=604800"
         }
       ]
+    },
+    {
+      "source": "/manifest.json",
+      "headers": [
+        {
+          "key": "Access-Control-Allow-Origin",
+          "value": "*"
+        }
+      ]
     }
   ]
 }

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -256,7 +256,7 @@ class Routes extends React.Component<WithStyles<typeof styles>, { openDrawer: bo
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                <Icon className={classNames('fa', 'fa-github', classes.leftIcon)} />
+                <Icon className={classNames('fas', 'fa-code', classes.leftIcon)} />
                 <span className="d-none d-md-block">GitHub</span>
               </Button>
               <Button

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -256,7 +256,7 @@ class Routes extends React.Component<WithStyles<typeof styles>, { openDrawer: bo
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                <Icon className={classNames('fas', 'fa-code', classes.leftIcon)} />
+                <Icon className={classNames('fas', 'fa-file-code', classes.leftIcon)} />
                 <span className="d-none d-md-block">Source</span>
               </Button>
               <Button

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -257,7 +257,7 @@ class Routes extends React.Component<WithStyles<typeof styles>, { openDrawer: bo
                 rel="noopener noreferrer"
               >
                 <Icon className={classNames('fas', 'fa-code', classes.leftIcon)} />
-                <span className="d-none d-md-block">GitHub</span>
+                <span className="d-none d-md-block">Source</span>
               </Button>
               <Button
                 style={{ color: cirrusColors.cirrusWhite, marginRight: 8 }}

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -256,7 +256,7 @@ class Routes extends React.Component<WithStyles<typeof styles>, { openDrawer: bo
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                <Icon className={classNames('fas', 'fa-file-code', classes.leftIcon)} />
+                <Icon className={classNames('fa', 'fa-code', classes.leftIcon)} />
                 <span className="d-none d-md-block">Source</span>
               </Button>
               <Button


### PR DESCRIPTION
Use `fa-code` as this is the source.
The duplicate GitHub icons look ugly together.