### PR TITLE
Made the compute credit cost tooltip less confusing

### DIFF
--- a/src/components/chips/TaskTransactionChip.tsx
+++ b/src/components/chips/TaskTransactionChip.tsx
@@ -13,7 +13,7 @@ function TaskTransactionChip(props) {
   let { task } = props;
   let { transaction, usedComputeCredits } = task;
   if (!usedComputeCredits) return <div />;
-  let tip = "Compute credit cost will be calculated at the end of the task.";
+  let tip = 'Compute credit cost will be calculated at the end of the task.';
   if (transaction) {
     tip = `${transaction.creditsAmount} compute credits were charged for this task.`;
   }

--- a/src/components/chips/TaskTransactionChip.tsx
+++ b/src/components/chips/TaskTransactionChip.tsx
@@ -13,7 +13,7 @@ function TaskTransactionChip(props) {
   let { task } = props;
   let { transaction, usedComputeCredits } = task;
   if (!usedComputeCredits) return <div />;
-  let tip = "Compute credit cost will be calculated at the end of the build.";
+  let tip = "Compute credit cost will be calculated at the end of the task.";
   if (transaction) {
     tip = `${transaction.creditsAmount} compute credits were charged for this task.`;
   }

--- a/src/components/chips/TaskTransactionChip.tsx
+++ b/src/components/chips/TaskTransactionChip.tsx
@@ -13,9 +13,9 @@ function TaskTransactionChip(props) {
   let { task } = props;
   let { transaction, usedComputeCredits } = task;
   if (!usedComputeCredits) return <div />;
-  let tip = "Exact amount of compute credits used hasn't been calculated yet";
+  let tip = "Compute credit cost will be calculated at the end of the build.";
   if (transaction) {
-    tip = `${transaction.creditsAmount} compute credits were charged for this task`;
+    tip = `${transaction.creditsAmount} compute credits were charged for this task.`;
   }
   if (transaction && transaction.initialCreditsAmount) {
     tip += ` (corrected from ${transaction.initialCreditsAmount})`;


### PR DESCRIPTION
Tell the user exactly when compute credit cost will be calculated.