### PR TITLE
Remove canonical link tag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -61,7 +61,6 @@
     ></script>
     <script src="https://js.stripe.com/v3/" async></script>
     <title>Cirrus CI</title>
-    <link rel="canonical" href="https://cirrus-ci.com" />
   </head>
   <body>
     <noscript>You need to enable JavaScript to visit Cirrus CI.</noscript>


### PR DESCRIPTION
User noticed:

> all pages on your site have this HTML tag on them: <link rel="canonical" href="https://cirrus-ci.com"/> -- that is definitely not how the tag is supposed to be used. It tells search engines that every page on your site is really aliases for your homepage (as in identical content), which they are not. It's probably not a huge deal, but it is likely hurting your site's SEO (search engine rankings) on various search engines.