### PR TITLE
Add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,14 +4,14 @@ updates:
   - package-ecosystem: docker
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
       time: '12:00'
       timezone: EST
-    open-pull-requests-limit: 99
+    open-pull-requests-limit: 2
   - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
       time: '12:00'
       timezone: EST
     open-pull-requests-limit: 99

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+
+updates:
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: daily
+      time: '12:00'
+      timezone: EST
+    open-pull-requests-limit: 99
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+      time: '12:00'
+      timezone: EST
+    open-pull-requests-limit: 99
+    allow:
+      - dependency-type: direct
+      - dependency-type: indirect


### PR DESCRIPTION
Since dependabot is moving into github (big annoyance), this file has to be added to configure it so it actually works once the web app is fully removed.  No other installs are required, just to merge the PR.   