### PR TITLE
Fix minor color issue

### DIFF
--- a/src/components/chips/TaskResourcesChip.tsx
+++ b/src/components/chips/TaskResourcesChip.tsx
@@ -12,7 +12,7 @@ import { TaskResourcesChip_task } from './__generated__/TaskResourcesChip_task.g
 const styles = theme =>
   createStyles({
     avatar: {
-      backgroundColor: theme.palette.secondary.main,
+      backgroundColor: theme.palette.primary.main,
     },
     avatarIcon: {
       color: theme.palette.primary.contrastText,


### PR DESCRIPTION
Changes the color of the chip so that it doesn't blend in with the background of the chip.
It looked like this before:
![Capture](https://user-images.githubusercontent.com/34555510/108274956-9286fe00-7143-11eb-9750-7a4599d1f47e.PNG)

Now the background of the icon is just black like a lot of the other chips.  