### PR TITLE
Increase short SHA size to 7 hexdigits

### DIFF
--- a/src/components/builds/BuildDetails.tsx
+++ b/src/components/builds/BuildDetails.tsx
@@ -252,7 +252,7 @@ function BuildDetails(props: Props) {
           <Typography variant="subtitle1" gutterBottom>
             Commit{' '}
             <a href={commitUrl} target="_blank" rel="noopener noreferrer">
-              {build.changeIdInRepo.substr(0, 6)}
+              {build.changeIdInRepo.substr(0, 7)}
             </a>{' '}
             on branch{' '}
             <a href={branchUrl} target="_blank" rel="noopener noreferrer">

--- a/src/components/chips/BuildChangeChip.tsx
+++ b/src/components/chips/BuildChangeChip.tsx
@@ -29,7 +29,7 @@ function BuildChangeChip(props: Props) {
   let history = useHistory();
   return (
     <Chip
-      label={build.changeIdInRepo.substr(0, 6)}
+      label={build.changeIdInRepo.substr(0, 7)}
       avatar={
         <Avatar className={props.classes.avatar}>
           <Input className={props.classes.avatarIcon} />

--- a/src/components/tasks/TaskDetails.tsx
+++ b/src/components/tasks/TaskDetails.tsx
@@ -338,7 +338,7 @@ function TaskDetails(props: Props, context) {
           <Typography variant="h6" gutterBottom>
             {build.changeMessageTitle} (commit{' '}
             <a href={commitUrl} target="_blank" rel="noopener noreferrer">
-              {build.changeIdInRepo.substr(0, 6)}
+              {build.changeIdInRepo.substr(0, 7)}
             </a>{' '}
             on branch{' '}
             <a href={branchUrl} target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
...to that of used on GitHub and the Git's original [7-hexdigit default](https://github.com/git/git/commit/e6c587c733b4634030b353f4024794b08bc86892), so that <kbd>Ctrl+F</kbd> works for searching builds.