### PR TITLE
Display the user who re-ran or cancelled a task

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -889,6 +889,8 @@ type Task {
   executionInfo: ExecutionInfo
   baseEnvironment: [String]
   hooks: [Hook]
+  reranBy: UserBasicInfo
+  cancelledBy: UserBasicInfo
 }
 
 input TaskAbortInput {
@@ -1044,7 +1046,7 @@ type UpdatePersistentWorkerPoolPayload {
   clientMutationId: String
 }
 
-type User {
+type User implements UserBasicInfo {
   id: ID!
   githubUserId: Int
   githubUserName: String!
@@ -1099,6 +1101,13 @@ type User {
   apiToken: ApiAccessToken
   webPushServerKey: String!
   persistentWorkerPools: [PersistentWorkerPool]
+}
+
+interface UserBasicInfo {
+  id: ID!
+  githubUserId: Int
+  githubUserName: String
+  avatarURL: String
 }
 
 """

--- a/src/components/chips/TaskCancellerChip.tsx
+++ b/src/components/chips/TaskCancellerChip.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import Avatar from '@material-ui/core/Avatar';
+import Chip from '@material-ui/core/Chip';
+
+import { createFragmentContainer } from 'react-relay';
+import { graphql } from 'babel-plugin-relay/macro';
+import { Cancel } from '@material-ui/icons';
+import { TaskCancellerChip_task } from './__generated__/TaskCancellerChip_task.graphql';
+
+interface Props {
+  task: TaskCancellerChip_task;
+  className?: string;
+}
+
+function TaskCancellerChip(props: Props) {
+  let { cancelledBy } = props.task;
+
+  if (!cancelledBy) return <></>;
+
+  return (
+    <Chip
+      className={props.className}
+      label={'Cancelled by ' + cancelledBy.githubUserName}
+      avatar={
+        <Avatar>
+          <Cancel />
+        </Avatar>
+      }
+      onClick={() => {
+        window.open('https://github.com/' + cancelledBy.githubUserName);
+      }}
+    />
+  );
+}
+
+export default createFragmentContainer(TaskCancellerChip, {
+  task: graphql`
+    fragment TaskCancellerChip_task on Task {
+      cancelledBy {
+        githubUserName
+      }
+    }
+  `,
+});

--- a/src/components/chips/TaskRerunnerChip.tsx
+++ b/src/components/chips/TaskRerunnerChip.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import Avatar from '@material-ui/core/Avatar';
+import Chip from '@material-ui/core/Chip';
+
+import { createFragmentContainer } from 'react-relay';
+import { graphql } from 'babel-plugin-relay/macro';
+import { TaskRerunnerChip_task } from './__generated__/TaskRerunnerChip_task.graphql';
+import { Refresh } from '@material-ui/icons';
+
+interface Props {
+  task: TaskRerunnerChip_task;
+  className?: string;
+}
+
+function TaskRerunnerChip(props: Props) {
+  let { reranBy } = props.task;
+
+  if (!reranBy) return <></>;
+
+  return (
+    <Chip
+      className={props.className}
+      label={'Re-ran by ' + reranBy.githubUserName}
+      avatar={
+        <Avatar>
+          <Refresh />
+        </Avatar>
+      }
+      onClick={() => {
+        window.open('https://github.com/' + reranBy.githubUserName);
+      }}
+    />
+  );
+}
+
+export default createFragmentContainer(TaskRerunnerChip, {
+  task: graphql`
+    fragment TaskRerunnerChip_task on Task {
+      reranBy {
+        githubUserName
+      }
+    }
+  `,
+});

--- a/src/components/tasks/TaskDetails.tsx
+++ b/src/components/tasks/TaskDetails.tsx
@@ -48,6 +48,8 @@ import { TabContext, TabList, TabPanel } from '@material-ui/lab';
 import { AppBar, Tab, Tooltip } from '@material-ui/core';
 import { Dehaze, Functions, LayersClear } from '@material-ui/icons';
 import { TaskDetailsInvalidateCachesMutationResponse } from './__generated__/TaskDetailsInvalidateCachesMutation.graphql';
+import TaskRerunnerChip from '../chips/TaskRerunnerChip';
+import TaskCancellerChip from '../chips/TaskCancellerChip';
 
 const taskReRunMutation = graphql`
   mutation TaskDetailsReRunMutation($input: TaskReRunInput!) {
@@ -415,6 +417,10 @@ function TaskDetails(props: Props, context) {
             <TaskScheduledChip className={classes.chip} task={task} />
             <TaskStatusChip className={classes.chip} task={task} />
           </div>
+          <div className={classes.wrapper}>
+            <TaskRerunnerChip className={classes.chip} task={task} />
+            <TaskCancellerChip className={classes.chip} task={task} />
+          </div>
           <TaskCommandsProgress className={classes.progress} task={task} />
           <div className={classes.gap} />
           <Typography variant="h6" gutterBottom>
@@ -494,6 +500,8 @@ export default createFragmentContainer(withStyles(styles)(withRouter(TaskDetails
       ...TaskTimeoutChip_task
       ...TaskStatefulChip_task
       ...TaskOptionalChip_task
+      ...TaskRerunnerChip_task
+      ...TaskCancellerChip_task
       labels
       artifacts {
         name


### PR DESCRIPTION
Looks like this:

<img width="1123" alt="Screenshot 2021-06-07 at 23 37 06" src="https://user-images.githubusercontent.com/85709/121084536-6cb46080-c7e9-11eb-8cbf-a7a324486bb0.png">

The chips are clickable.

Resolves https://github.com/cirruslabs/cirrus-ci-web/issues/375.