### PR TITLE
InlineLogs: handle null values

### DIFF
--- a/src/components/logs/InlineLogs.tsx
+++ b/src/components/logs/InlineLogs.tsx
@@ -44,6 +44,10 @@ interface Props extends WithStyles<typeof styles> {
 function InlineLogs(props: Props) {
   let { title, lines, classes } = props;
 
+  if (!lines) {
+    lines = [''];
+  }
+
   const tableRows = lines.map((lineContent, zeroBasedLineNumber) => [
     <tr>
       <td className={classes.lineNumber}>{zeroBasedLineNumber + 1}</td>

--- a/src/components/tasks/TaskDebuggingInformation.tsx
+++ b/src/components/tasks/TaskDebuggingInformation.tsx
@@ -35,12 +35,10 @@ function TaskDebuggingInformation(props: Props) {
           return null;
         }
         let task = response.props.task;
-        let events = !task.executionInfo
-          ? []
-          : task.executionInfo.events.map(event => {
-              let prettyTime = new Date(event.timestamp).toLocaleTimeString();
-              return `${prettyTime} ${event.message}`;
-            });
+        let events = task.executionInfo?.events.map(event => {
+          let prettyTime = new Date(event.timestamp).toLocaleTimeString();
+          return `${prettyTime} ${event.message}`;
+        });
         return (
           <Card elevation={24}>
             <CardContent>


### PR DESCRIPTION
An example of a task with no execution events and agent logs: http://cirrus-ci.com/task/5393919098748928.