### PR TITLE
Simple "markdown" in commit messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ docker run -p 8080:8080 cirrusci/web-front-end:latest
 ## Authentication from localhost
 
 In order to authenticate with `api.cirrus-ci.com` from locally running Cirrus CI Web, login on [cirrus-ci.com](https://cirrus-ci.com),
-and remove the `Same-Site` restrictions for `cirrusUserId` and `cirrusAuthToken` cookies (for `api.cirrus-ci.com`). ([EditThisCookie](http://www.editthiscookie.com/)
+and remove the `Same-Site` restrictions for `cirrusUserId` and `cirrusAuthToken` cookies (for `api.cirrus-ci.com`, on Firefox this means setting `Secure` to `false`). ([EditThisCookie](http://www.editthiscookie.com/)
 works just fine for it).
 
 ### Productivity Tips

--- a/schema.graphql
+++ b/schema.graphql
@@ -169,17 +169,17 @@ type CacheRetrievalAttemptError {
 type CacheRetrievalAttemptHit {
   key: String!
   sizeBytes: Int!
-  downloadedInNanos: Int!
-  extractedInNanos: Int!
+  downloadedInMilliseconds: Int!
+  extractedInMilliseconds: Int!
   valid: Boolean!
 }
 
 type CacheRetrievalAttemptMiss {
   key: String!
   sizeBytes: Int!
-  populatedInNanos: Int!
-  archivedInNanos: Int!
-  uploadedInNanos: Int!
+  populatedInMilliseconds: Int!
+  archivedInMilliseconds: Int!
+  uploadedInMilliseconds: Int!
 }
 
 type CacheRetrievalAttempts {

--- a/src/components/account/ViewerBuildList.tsx
+++ b/src/components/account/ViewerBuildList.tsx
@@ -71,9 +71,13 @@ function ViewerBuildList(props: Props) {
         </TableCell>
         <TableCell className={classes.cell}>
           <div>
-            <Typography variant="body1" color="inherit">
-              <CommitTitle changeMessageTitle={build.changeMessageTitle} />
-            </Typography>
+            <CommitTitle
+              changeMessageTitle={build.changeMessageTitle}
+              typographyProps={{
+                variant: 'body1',
+                color: 'inherit',
+              }}
+            />
           </div>
         </TableCell>
         <TableCell className={classes.cell} sx={{ display: { xs: 'none', sm: 'table-cell' } }}>

--- a/src/components/account/ViewerBuildList.tsx
+++ b/src/components/account/ViewerBuildList.tsx
@@ -22,6 +22,7 @@ import withStyles from '@mui/styles/withStyles';
 import { ViewerBuildList_viewer } from './__generated__/ViewerBuildList_viewer.graphql';
 import { Helmet as Head } from 'react-helmet';
 import { Box } from '@mui/material';
+import { CommitTitle } from '../common/CommitMessage';
 
 const styles = theme => ({
   chip: {
@@ -71,7 +72,7 @@ function ViewerBuildList(props: Props) {
         <TableCell className={classes.cell}>
           <div>
             <Typography variant="body1" color="inherit">
-              {build.changeMessageTitle}
+              <CommitTitle changeMessageTitle={build.changeMessageTitle} />
             </Typography>
           </div>
         </TableCell>

--- a/src/components/builds/BuildDetails.tsx
+++ b/src/components/builds/BuildDetails.tsx
@@ -136,6 +136,7 @@ function BuildDetails(props: Props) {
     };
   }, [props.build.id]);
   const { build, classes } = props;
+  const repository = build.repository;
 
   function approveBuild() {
     const variables: BuildDetailsApproveBuildMutationVariables = {
@@ -298,7 +299,12 @@ function BuildDetails(props: Props) {
             </div>
           </Box>
           <div className={classes.gap} />
-          <CommitMessage build={build} />
+          <CommitMessage
+            cloneUrl={repository.cloneUrl}
+            branch={build.branch}
+            changeIdInRepo={build.changeIdInRepo}
+            changeMessageTitle={build.changeMessageTitle}
+          />
         </CardContent>
         <CardActions sx={{ justifyContent: 'flex-end' }}>
           {reTriggerButton}

--- a/src/components/builds/BuildDetails.tsx
+++ b/src/components/builds/BuildDetails.tsx
@@ -6,7 +6,6 @@ import Card from '@mui/material/Card';
 import CardActions from '@mui/material/CardActions';
 import CardContent from '@mui/material/CardContent';
 import Paper from '@mui/material/Paper';
-import Typography from '@mui/material/Typography';
 import { graphql } from 'babel-plugin-relay/macro';
 import React, { useEffect } from 'react';
 import { commitMutation, createFragmentContainer, requestSubscription } from 'react-relay';
@@ -25,7 +24,7 @@ import BuildBranchNameChip from '../chips/BuildBranchNameChip';
 import Notification from '../common/Notification';
 import ConfigurationWithIssues from './ConfigurationWithIssues';
 import HookList from '../hooks/HookList';
-import { Box, Collapse, Link, List, Tab, ToggleButton } from '@mui/material';
+import { Box, Collapse, List, Tab, ToggleButton } from '@mui/material';
 import { TabContext, TabList, TabPanel } from '@mui/lab';
 import { BugReport, Cancel, Dehaze, Functions } from '@mui/icons-material';
 import Tooltip from '@mui/material/Tooltip';
@@ -36,6 +35,7 @@ import { BuildDetailsApproveBuildMutationVariables } from './__generated__/Build
 import { BuildDetailsReTriggerMutationVariables } from './__generated__/BuildDetailsReTriggerMutation.graphql';
 import { BuildDetailsReRunMutationVariables } from './__generated__/BuildDetailsReRunMutation.graphql';
 import { BuildDetailsCancelMutationVariables } from './__generated__/BuildDetailsCancelMutation.graphql';
+import CommitMessage from '../common/CommitMessage';
 
 const buildApproveMutation = graphql`
   mutation BuildDetailsApproveBuildMutation($input: BuildApproveInput!) {
@@ -199,10 +199,6 @@ function BuildDetails(props: Props) {
     });
   }
 
-  const repoUrl = build.repository.cloneUrl.slice(0, -4);
-  const branchUrl = build.branch.startsWith('pull/') ? `${repoUrl}/${build.branch}` : `${repoUrl}/tree/${build.branch}`;
-  const commitUrl = repoUrl + '/commit/' + build.changeIdInRepo;
-
   const notificationsComponent = !build.notifications ? null : (
     <List>
       {build.notifications.map(notification => (
@@ -302,20 +298,7 @@ function BuildDetails(props: Props) {
             </div>
           </Box>
           <div className={classes.gap} />
-          <Typography variant="h6" gutterBottom>
-            {build.changeMessageTitle}
-          </Typography>
-          <Typography variant="subtitle1" gutterBottom>
-            Commit{' '}
-            <Link href={commitUrl} color="inherit" target="_blank" rel="noopener noreferrer">
-              {build.changeIdInRepo.substr(0, 7)}
-            </Link>{' '}
-            on branch{' '}
-            <Link href={branchUrl} color="inherit" target="_blank" rel="noopener noreferrer">
-              {build.branch}
-            </Link>
-            .
-          </Typography>
+          <CommitMessage build={build} />
         </CardContent>
         <CardActions sx={{ justifyContent: 'flex-end' }}>
           {reTriggerButton}

--- a/src/components/builds/LastDefaultBranchBuildMiniRow.tsx
+++ b/src/components/builds/LastDefaultBranchBuildMiniRow.tsx
@@ -10,7 +10,6 @@ import withStyles from '@mui/styles/withStyles';
 import { navigateBuildHelper } from '../../utils/navigateHelper';
 import RepositoryNameChip from '../chips/RepositoryNameChip';
 import BuildStatusChip from '../chips/BuildStatusChip';
-import Typography from '@mui/material/Typography';
 import { LastDefaultBranchBuildMiniRow_repository } from './__generated__/LastDefaultBranchBuildMiniRow_repository.graphql';
 import { useNavigate } from 'react-router-dom';
 import { CommitTitle } from '../common/CommitMessage';
@@ -71,9 +70,13 @@ function LastDefaultBranchBuildRow(props: Props) {
           <BuildStatusChip build={build} mini={true} className={classes.chip} />
         </div>
         <div className={classes.message}>
-          <Typography variant="body1" color="inherit">
-            <CommitTitle changeMessageTitle={build.changeMessageTitle} />
-          </Typography>
+          <CommitTitle
+            changeMessageTitle={build.changeMessageTitle}
+            typographyProps={{
+              variant: 'body1',
+              color: 'inherit',
+            }}
+          />
         </div>
       </TableCell>
     </TableRow>

--- a/src/components/builds/LastDefaultBranchBuildMiniRow.tsx
+++ b/src/components/builds/LastDefaultBranchBuildMiniRow.tsx
@@ -13,6 +13,7 @@ import BuildStatusChip from '../chips/BuildStatusChip';
 import Typography from '@mui/material/Typography';
 import { LastDefaultBranchBuildMiniRow_repository } from './__generated__/LastDefaultBranchBuildMiniRow_repository.graphql';
 import { useNavigate } from 'react-router-dom';
+import { CommitTitle } from '../common/CommitMessage';
 
 const buildSubscription = graphql`
   subscription LastDefaultBranchBuildMiniRowSubscription($repositoryID: ID!) {
@@ -71,7 +72,7 @@ function LastDefaultBranchBuildRow(props: Props) {
         </div>
         <div className={classes.message}>
           <Typography variant="body1" color="inherit">
-            {build.changeMessageTitle}
+            <CommitTitle changeMessageTitle={build.changeMessageTitle} />
           </Typography>
         </div>
       </TableCell>

--- a/src/components/builds/LastDefaultBranchBuildRow.tsx
+++ b/src/components/builds/LastDefaultBranchBuildRow.tsx
@@ -12,7 +12,6 @@ import RepositoryNameChip from '../chips/RepositoryNameChip';
 import BuildStatusChip from '../chips/BuildStatusChip';
 import classNames from 'classnames';
 import BuildChangeChip from '../chips/BuildChangeChip';
-import Typography from '@mui/material/Typography';
 import { LastDefaultBranchBuildRow_repository } from './__generated__/LastDefaultBranchBuildRow_repository.graphql';
 import { CommitTitle } from '../common/CommitMessage';
 
@@ -72,19 +71,24 @@ function LastDefaultBranchBuildRow(props: Props) {
           <RepositoryNameChip repository={repository} className={classes.chip} />
           <BuildChangeChip build={repository.lastDefaultBranchBuild} className={classes.chip} />
         </div>
-        <Typography
-          variant="body1"
-          color="inherit"
-          className={classes.message}
-          sx={{ display: { xs: 'block', sm: 'none' } }}
-        >
-          <CommitTitle changeMessageTitle={build.changeMessageTitle} />
-        </Typography>
+        <CommitTitle
+          changeMessageTitle={build.changeMessageTitle}
+          typographyProps={{
+            variant: 'body1',
+            color: 'inherit',
+            className: classes.message,
+            sx: { display: { xs: 'block', sm: 'none' } },
+          }}
+        />
       </TableCell>
       <TableCell className={classNames(classes.cell, classes.message)}>
-        <Typography variant="body1" color="inherit">
-          <CommitTitle changeMessageTitle={build.changeMessageTitle} />
-        </Typography>
+        <CommitTitle
+          changeMessageTitle={build.changeMessageTitle}
+          typographyProps={{
+            variant: 'body1',
+            color: 'inherit',
+          }}
+        />
       </TableCell>
       <TableCell className={classes.cell}>
         <BuildStatusChip build={build} className={classNames('pull-right', classes.chip)} />

--- a/src/components/builds/LastDefaultBranchBuildRow.tsx
+++ b/src/components/builds/LastDefaultBranchBuildRow.tsx
@@ -14,6 +14,7 @@ import classNames from 'classnames';
 import BuildChangeChip from '../chips/BuildChangeChip';
 import Typography from '@mui/material/Typography';
 import { LastDefaultBranchBuildRow_repository } from './__generated__/LastDefaultBranchBuildRow_repository.graphql';
+import { CommitTitle } from '../common/CommitMessage';
 
 const buildSubscription = graphql`
   subscription LastDefaultBranchBuildRowSubscription($repositoryID: ID!) {
@@ -77,12 +78,12 @@ function LastDefaultBranchBuildRow(props: Props) {
           className={classes.message}
           sx={{ display: { xs: 'block', sm: 'none' } }}
         >
-          {build.changeMessageTitle}
+          <CommitTitle changeMessageTitle={build.changeMessageTitle} />
         </Typography>
       </TableCell>
       <TableCell className={classNames(classes.cell, classes.message)}>
         <Typography variant="body1" color="inherit">
-          {build.changeMessageTitle}
+          <CommitTitle changeMessageTitle={build.changeMessageTitle} />
         </Typography>
       </TableCell>
       <TableCell className={classes.cell}>

--- a/src/components/common/CommitMessage.tsx
+++ b/src/components/common/CommitMessage.tsx
@@ -15,20 +15,18 @@ function CommitMessage(props: Props) {
   const commitUrl = repoUrl + '/commit/' + changeIdInRepo;
 
   const bits = changeMessageTitle.split('`');
-  let renderedTitle: JSX.Element[] = [<>{bits[0]}</>];
+  let renderedTitle: JSX.Element[] = [];
 
-  if (bits.length > 1) {
-    let state = 0;
+  let state = 0;
 
-    for (let bit of bits.slice(1, bits.length)) {
-      if (state) {
-        renderedTitle.push(<>{bit}</>);
-      } else {
-        renderedTitle.push(<code>{bit}</code>);
-      }
-
-      state ^= 1;
+  for (let bit of bits) {
+    if (state) {
+      renderedTitle.push(<code>{bit}</code>);
+    } else {
+      renderedTitle.push(<>{bit}</>);
     }
+
+    state ^= 1;
   }
 
   return (

--- a/src/components/common/CommitMessage.tsx
+++ b/src/components/common/CommitMessage.tsx
@@ -1,36 +1,22 @@
-import { Link, Typography } from '@mui/material';
+import { Link, Typography, TypographyProps } from '@mui/material';
+import ReactMarkdown from 'react-markdown';
 
 interface CommitTitleProps {
   changeMessageTitle: string;
+  typographyProps?: TypographyProps;
 }
 
 export function CommitTitle(props: CommitTitleProps) {
-  const { changeMessageTitle } = props;
+  const { changeMessageTitle, typographyProps } = props;
 
-  const bits = changeMessageTitle.split('`');
-  let renderedTitle: JSX.Element[] = [];
-
-  if (bits.length % 2) {
-    let state = 0;
-
-    for (let bit of bits) {
-      if (state) {
-        renderedTitle.push(<code>{bit}</code>);
-      } else {
-        renderedTitle.push(<>{bit}</>);
-      }
-
-      state ^= 1;
-    }
-  } else {
-    renderedTitle.push(<>{bits[0]}</>);
-
-    for (let bit of bits.slice(1, bits.length)) {
-      renderedTitle.push(<>`{bit}</>);
-    }
-  }
-
-  return <>{renderedTitle}</>;
+  return (
+    <ReactMarkdown
+      source={changeMessageTitle}
+      renderers={{
+        paragraph: ({ children }) => <Typography {...typographyProps}>{children}</Typography>,
+      }}
+    />
+  );
 }
 
 interface CommitMessageProps extends CommitTitleProps {
@@ -48,9 +34,13 @@ export default function CommitMessage(props: CommitMessageProps) {
 
   return (
     <>
-      <Typography variant="h6" gutterBottom>
-        <CommitTitle changeMessageTitle={changeMessageTitle} />
-      </Typography>
+      <CommitTitle
+        changeMessageTitle={changeMessageTitle}
+        typographyProps={{
+          variant: 'h6',
+          gutterBottom: true,
+        }}
+      />
       <Typography variant="subtitle1" gutterBottom>
         Commit{' '}
         <Link href={commitUrl} color="inherit" target="_blank" rel="noopener noreferrer">

--- a/src/components/common/CommitMessage.tsx
+++ b/src/components/common/CommitMessage.tsx
@@ -1,33 +1,16 @@
 import { Link, Typography } from '@mui/material';
-import { BuildDetails_build } from '../builds/__generated__/BuildDetails_build.graphql';
-import { TaskDetails_task } from '../tasks/__generated__/TaskDetails_task.graphql';
 
 interface Props {
-  task?: TaskDetails_task;
-  build?: BuildDetails_build;
+  cloneUrl: string;
+  branch: string;
+  changeIdInRepo: string;
+  changeMessageTitle: string;
 }
 
 function CommitMessage(props: Props) {
-  const { task, build } = props;
+  const { cloneUrl, branch, changeIdInRepo, changeMessageTitle } = props;
 
-  let repository;
-  let branch;
-  let changeIdInRepo;
-  let changeMessageTitle;
-
-  if (task) {
-    repository = task.repository;
-    branch = task.build.branch;
-    changeIdInRepo = task.build.changeIdInRepo;
-    changeMessageTitle = task.build.changeMessageTitle;
-  } else if (build) {
-    repository = build.repository;
-    branch = build.branch;
-    changeIdInRepo = build.changeIdInRepo;
-    changeMessageTitle = build.changeMessageTitle;
-  }
-
-  const repoUrl = repository.cloneUrl.slice(0, -4);
+  const repoUrl = cloneUrl.slice(0, -4);
   const branchUrl = branch.startsWith('pull/') ? `${repoUrl}/${branch}` : `${repoUrl}/tree/${branch}`;
   const commitUrl = repoUrl + '/commit/' + changeIdInRepo;
 

--- a/src/components/common/CommitMessage.tsx
+++ b/src/components/common/CommitMessage.tsx
@@ -1,0 +1,54 @@
+import { Link, Typography } from '@mui/material';
+import { BuildDetails_build } from '../builds/__generated__/BuildDetails_build.graphql';
+import { TaskDetails_task } from '../tasks/__generated__/TaskDetails_task.graphql';
+
+interface Props {
+  task?: TaskDetails_task;
+  build?: BuildDetails_build;
+}
+
+function CommitMessage(props: Props) {
+  const { task, build } = props;
+
+  let repository;
+  let branch;
+  let changeIdInRepo;
+  let changeMessageTitle;
+
+  if (task) {
+    repository = task.repository;
+    branch = task.build.branch;
+    changeIdInRepo = task.build.changeIdInRepo;
+    changeMessageTitle = task.build.changeMessageTitle;
+  } else if (build) {
+    repository = build.repository;
+    branch = build.branch;
+    changeIdInRepo = build.changeIdInRepo;
+    changeMessageTitle = build.changeMessageTitle;
+  }
+
+  const repoUrl = repository.cloneUrl.slice(0, -4);
+  const branchUrl = branch.startsWith('pull/') ? `${repoUrl}/${branch}` : `${repoUrl}/tree/${branch}`;
+  const commitUrl = repoUrl + '/commit/' + changeIdInRepo;
+
+  return (
+    <>
+      <Typography variant="h6" gutterBottom>
+        {changeMessageTitle}
+      </Typography>
+      <Typography variant="subtitle1" gutterBottom>
+        Commit{' '}
+        <Link href={commitUrl} color="inherit" target="_blank" rel="noopener noreferrer">
+          {changeIdInRepo.substr(0, 7)}
+        </Link>{' '}
+        on branch{' '}
+        <Link href={branchUrl} color="inherit" target="_blank" rel="noopener noreferrer">
+          {branch}
+        </Link>
+        .
+      </Typography>
+    </>
+  );
+}
+
+export default CommitMessage;

--- a/src/components/common/CommitMessage.tsx
+++ b/src/components/common/CommitMessage.tsx
@@ -14,10 +14,27 @@ function CommitMessage(props: Props) {
   const branchUrl = branch.startsWith('pull/') ? `${repoUrl}/${branch}` : `${repoUrl}/tree/${branch}`;
   const commitUrl = repoUrl + '/commit/' + changeIdInRepo;
 
+  const bits = changeMessageTitle.split('`');
+  let renderedTitle: JSX.Element[] = [<>{bits[0]}</>];
+
+  if (bits.length > 1) {
+    let state = 0;
+
+    for (let bit of bits.slice(1, bits.length)) {
+      if (state) {
+        renderedTitle.push(<>{bit}</>);
+      } else {
+        renderedTitle.push(<code>{bit}</code>);
+      }
+
+      state ^= 1;
+    }
+  }
+
   return (
     <>
       <Typography variant="h6" gutterBottom>
-        {changeMessageTitle}
+        {renderedTitle}
       </Typography>
       <Typography variant="subtitle1" gutterBottom>
         Commit{' '}

--- a/src/components/common/CommitMessage.tsx
+++ b/src/components/common/CommitMessage.tsx
@@ -1,18 +1,11 @@
 import { Link, Typography } from '@mui/material';
 
-interface Props {
-  cloneUrl: string;
-  branch: string;
-  changeIdInRepo: string;
+interface CommitTitleProps {
   changeMessageTitle: string;
 }
 
-function CommitMessage(props: Props) {
-  const { cloneUrl, branch, changeIdInRepo, changeMessageTitle } = props;
-
-  const repoUrl = cloneUrl.slice(0, -4);
-  const branchUrl = branch.startsWith('pull/') ? `${repoUrl}/${branch}` : `${repoUrl}/tree/${branch}`;
-  const commitUrl = repoUrl + '/commit/' + changeIdInRepo;
+export function CommitTitle(props: CommitTitleProps) {
+  const { changeMessageTitle } = props;
 
   const bits = changeMessageTitle.split('`');
   let renderedTitle: JSX.Element[] = [];
@@ -37,10 +30,26 @@ function CommitMessage(props: Props) {
     }
   }
 
+  return <>{renderedTitle}</>;
+}
+
+interface CommitMessageProps extends CommitTitleProps {
+  cloneUrl: string;
+  branch: string;
+  changeIdInRepo: string;
+}
+
+export default function CommitMessage(props: CommitMessageProps) {
+  const { cloneUrl, branch, changeIdInRepo, changeMessageTitle } = props;
+
+  const repoUrl = cloneUrl.slice(0, -4);
+  const branchUrl = branch.startsWith('pull/') ? `${repoUrl}/${branch}` : `${repoUrl}/tree/${branch}`;
+  const commitUrl = repoUrl + '/commit/' + changeIdInRepo;
+
   return (
     <>
       <Typography variant="h6" gutterBottom>
-        {renderedTitle}
+        <CommitTitle changeMessageTitle={changeMessageTitle} />
       </Typography>
       <Typography variant="subtitle1" gutterBottom>
         Commit{' '}
@@ -56,5 +65,3 @@ function CommitMessage(props: Props) {
     </>
   );
 }
-
-export default CommitMessage;

--- a/src/components/common/CommitMessage.tsx
+++ b/src/components/common/CommitMessage.tsx
@@ -17,16 +17,24 @@ function CommitMessage(props: Props) {
   const bits = changeMessageTitle.split('`');
   let renderedTitle: JSX.Element[] = [];
 
-  let state = 0;
+  if (bits.length % 2) {
+    let state = 0;
 
-  for (let bit of bits) {
-    if (state) {
-      renderedTitle.push(<code>{bit}</code>);
-    } else {
-      renderedTitle.push(<>{bit}</>);
+    for (let bit of bits) {
+      if (state) {
+        renderedTitle.push(<code>{bit}</code>);
+      } else {
+        renderedTitle.push(<>{bit}</>);
+      }
+
+      state ^= 1;
     }
+  } else {
+    renderedTitle.push(<>{bits[0]}</>);
 
-    state ^= 1;
+    for (let bit of bits.slice(1, bits.length)) {
+      renderedTitle.push(<>`{bit}</>);
+    }
   }
 
   return (

--- a/src/components/repositories/RepositoryBuildList.tsx
+++ b/src/components/repositories/RepositoryBuildList.tsx
@@ -30,6 +30,7 @@ import AddCircle from '@mui/icons-material/AddCircle';
 import Timeline from '@mui/icons-material/Timeline';
 import environment from '../../createRelayEnvironment';
 import { Box, Link } from '@mui/material';
+import { CommitTitle } from '../common/CommitMessage';
 
 const styles = theme => ({
   gap: {
@@ -170,7 +171,7 @@ function RepositoryBuildList(props: Props) {
         <TableCell className={classes.cell}>
           <div>
             <Typography variant="body1" color="inherit">
-              {build.changeMessageTitle}
+              <CommitTitle changeMessageTitle={build.changeMessageTitle} />
             </Typography>
           </div>
         </TableCell>

--- a/src/components/repositories/RepositoryBuildList.tsx
+++ b/src/components/repositories/RepositoryBuildList.tsx
@@ -170,9 +170,13 @@ function RepositoryBuildList(props: Props) {
         </TableCell>
         <TableCell className={classes.cell}>
           <div>
-            <Typography variant="body1" color="inherit">
-              <CommitTitle changeMessageTitle={build.changeMessageTitle} />
-            </Typography>
+            <CommitTitle
+              changeMessageTitle={build.changeMessageTitle}
+              typographyProps={{
+                variant: 'body1',
+                color: 'inherit',
+              }}
+            />
           </div>
         </TableCell>
         <TableCell

--- a/src/components/tasks/TaskDetails.tsx
+++ b/src/components/tasks/TaskDetails.tsx
@@ -548,7 +548,12 @@ function TaskDetails(props: Props) {
           <div className={classes.gap} />
           <TaskCommandsProgress className={classes.progress} task={task} />
           <div className={classes.gap} />
-          <CommitMessage task={task} />
+          <CommitMessage
+            cloneUrl={repository.cloneUrl}
+            branch={build.branch}
+            changeIdInRepo={build.changeIdInRepo}
+            changeMessageTitle={build.changeMessageTitle}
+          />
           <div className={classes.gap} />
           <div className={classNames('card-body', classes.wrapper)}>
             {task.automaticReRun ? (

--- a/src/components/tasks/TaskDetails.tsx
+++ b/src/components/tasks/TaskDetails.tsx
@@ -58,7 +58,6 @@ import {
   Collapse,
   Grow,
   IconButton,
-  Link,
   List,
   MenuItem,
   MenuList,
@@ -84,6 +83,7 @@ import { TaskDetailsTriggerMutationVariables } from './__generated__/TaskDetails
 import { TaskDetailsCancelMutationVariables } from './__generated__/TaskDetailsCancelMutation.graphql';
 import TaskDebuggingInformation from './TaskDebuggingInformation';
 import CirrusLinearProgress from '../common/CirrusLinearProgress';
+import CommitMessage from '../common/CommitMessage';
 
 const taskReRunMutation = graphql`
   mutation TaskDetailsReRunMutation($input: TaskReRunInput!) {
@@ -251,10 +251,6 @@ function TaskDetails(props: Props) {
       onError: err => console.error(err),
     });
   }
-
-  let repoUrl = repository.cloneUrl.slice(0, -4);
-  let branchUrl = build.branch.startsWith('pull/') ? `${repoUrl}/${build.branch}` : `${repoUrl}/tree/${build.branch}`;
-  let commitUrl = repoUrl + '/commit/' + build.changeIdInRepo;
 
   let notificationsComponent =
     !task.notifications || task.notifications.length === 0 ? null : (
@@ -552,20 +548,7 @@ function TaskDetails(props: Props) {
           <div className={classes.gap} />
           <TaskCommandsProgress className={classes.progress} task={task} />
           <div className={classes.gap} />
-          <Typography variant="h6" gutterBottom>
-            {build.changeMessageTitle}
-          </Typography>
-          <Typography variant="subtitle1" gutterBottom>
-            Commit{' '}
-            <Link href={commitUrl} color="inherit" target="_blank" rel="noopener noreferrer">
-              {build.changeIdInRepo.substr(0, 7)}
-            </Link>{' '}
-            on branch{' '}
-            <Link href={branchUrl} color="inherit" target="_blank" rel="noopener noreferrer">
-              {build.branch}
-            </Link>
-            .
-          </Typography>
+          <CommitMessage task={task} />
           <div className={classes.gap} />
           <div className={classNames('card-body', classes.wrapper)}>
             {task.automaticReRun ? (

--- a/src/components/tasks/TaskDetails.tsx
+++ b/src/components/tasks/TaskDetails.tsx
@@ -553,7 +553,10 @@ function TaskDetails(props: Props) {
           <TaskCommandsProgress className={classes.progress} task={task} />
           <div className={classes.gap} />
           <Typography variant="h6" gutterBottom>
-            {build.changeMessageTitle} (commit{' '}
+            {build.changeMessageTitle}
+          </Typography>
+          <Typography variant="subtitle1" gutterBottom>
+            Commit{' '}
             <Link href={commitUrl} color="inherit" target="_blank" rel="noopener noreferrer">
               {build.changeIdInRepo.substr(0, 7)}
             </Link>{' '}
@@ -561,7 +564,7 @@ function TaskDetails(props: Props) {
             <Link href={branchUrl} color="inherit" target="_blank" rel="noopener noreferrer">
               {build.branch}
             </Link>
-            )
+            .
           </Typography>
           <div className={classes.gap} />
           <div className={classNames('card-body', classes.wrapper)}>


### PR DESCRIPTION
Another thing that's been bugging me for a while :smile: 

Similar to how GitHub renders commit messages:

![image](https://user-images.githubusercontent.com/11079650/147417402-a6cbf4fd-b8e4-4202-b0c3-83b8a3e52975.png)

Made it so that bits of commit messages surrounded by backticks (`) are rendered as inline code:

![image](https://user-images.githubusercontent.com/11079650/147417754-d1844303-9947-4c3d-8145-47eb535b469b.png)

This should be changed across the web interface, unless I accidentally missed a spot :P

In doing so, I refactored out a `CommitMessage` component for what was previously in `TaskDetails` & `BuildDetails` and also a `CommitTitle` component for everywhere else commit messages appear.