### PR TITLE
Use a different icon for tag builds

### DIFF
--- a/schema.gql
+++ b/schema.gql
@@ -58,13 +58,13 @@ type Build {
   id: ID!
   repositoryId: ID!
   branch: String!
+  tag: String
   changeIdInRepo: String!
   changeMessageTitle: String
   changeMessage: String
   durationInSeconds: Int
   clockDurationInSeconds: Int
   pullRequest: Int
-  checkSuiteId: Int
   isSenderUserCollaborator: Boolean
   senderUserPermissions: String
   changeTimestamp: Int!

--- a/src/components/chips/BuildBranchNameChip.tsx
+++ b/src/components/chips/BuildBranchNameChip.tsx
@@ -12,6 +12,8 @@ import { shorten } from '../../utils/text';
 import { WithStyles } from '@mui/styles';
 import createStyles from '@mui/styles/createStyles';
 import withStyles from '@mui/styles/withStyles';
+import { Commit } from '@mui/icons-material';
+import { Tooltip } from '@mui/material';
 
 const styles = theme =>
   createStyles({
@@ -44,6 +46,23 @@ function BuildBranchNameChip(props: Props) {
     }
   }
 
+  if (build.tag) {
+    return (
+      <Tooltip title={`${build.tag} tag`}>
+        <Chip
+          className={props.className}
+          label={shorten(build.branch)}
+          avatar={
+            <Avatar className={props.classes.avatar}>
+              <Commit className={props.classes.avatarIcon} />
+            </Avatar>
+          }
+          onClick={e => handleBranchClick(e)}
+        />
+      </Tooltip>
+    );
+  }
+
   return (
     <Chip
       className={props.className}
@@ -63,6 +82,7 @@ export default createFragmentContainer(withStyles(styles)(BuildBranchNameChip), 
     fragment BuildBranchNameChip_build on Build {
       id
       branch
+      tag
       repository {
         id
         owner


### PR DESCRIPTION
Related to https://github.com/cirruslabs/cirrus-ci-docs/issues/963

Here is a screenshot of how two builds will look like next to each other. One build is for a commit on a master branch and the second build is for a tag build.

<img width="289" alt="Screen Shot 2022-01-24 at 11 42 20 AM" src="https://user-images.githubusercontent.com/989066/150827025-732ff73c-6810-48c9-a1d0-9191691680fd.png">
