### PR TITLE
Update all the task details in subscription

### DIFF
--- a/src/components/tasks/TaskDetails.tsx
+++ b/src/components/tasks/TaskDetails.tsx
@@ -125,29 +125,7 @@ const invalidateCachesMutation = graphql`
 const taskSubscription = graphql`
   subscription TaskDetailsSubscription($taskID: ID!) {
     task(id: $taskID) {
-      id
-      name
-      status
-      labels
-      creationTimestamp
-      executingTimestamp
-      durationInSeconds
-      statusDurations {
-        status
-        durationInSeconds
-      }
-      commands {
-        name
-        status
-        durationInSeconds
-      }
-      notifications {
-        ...Notification_notification
-      }
-      terminalCredential {
-        locator
-        trustedSecret
-      }
+      ...TaskDetails_task
     }
   }
 `;


### PR DESCRIPTION
If a task is partially updated than the `executionInfo` and other stuff can be `null`. Let's play it smart and reuse the component query for the update.

Fixes #482