### PR TITLE
DRAFT! Table element for Repositories page

### DIFF
--- a/src/cirrusTheme.ts
+++ b/src/cirrusTheme.ts
@@ -18,14 +18,38 @@ export const muiThemeOptions = selector({
   },
 });
 
+let muiBaseTheme: ThemeOptions = {
+  components: {
+    MuiTableCell: {
+      styleOverrides: {
+        head: ({ theme }) => ({
+          fontSize: 14,
+          textTransform: 'uppercase',
+          paddingBottom: theme.spacing(1.5),
+          color: theme.palette.text.disabled,
+          '& *': { fontSize: '14px !important' },
+        }),
+        body: {
+          fontSize: 16,
+          '& *': { fontSize: '16px !important' },
+        },
+      },
+    },
+  },
+};
+
 export let muiLightTheme: ThemeOptions = {
+  ...muiBaseTheme,
   palette: {
+    ...muiBaseTheme.palette,
     mode: 'light',
   },
 };
 
 export let muiDarkTheme: ThemeOptions = {
+  ...muiBaseTheme,
   palette: {
+    ...muiBaseTheme.palette,
     mode: 'dark',
   },
 };

--- a/src/components/account/OwnerRepositoryList.tsx
+++ b/src/components/account/OwnerRepositoryList.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import Paper from '@mui/material/Paper';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import Tooltip from '@mui/material/Tooltip';
@@ -18,17 +17,20 @@ import { OwnerRepositoryList_info } from './__generated__/OwnerRepositoryList_in
 import AppBreadcrumbs from '../../components/common/AppBreadcrumbs';
 import createStyles from '@mui/styles/createStyles';
 import RepositoryTable from '../repositories/RepositoryTable';
+import usePageWidth from '../../utils/usePageWidth';
+import Paper from '../common/Paper';
 
 let styles = theme =>
   createStyles({
-    paper: {
-      padding: theme.spacing(1.0, 2.5, 1.5),
-      boxShadow: '0 16px 52px rgb(0 0 0 / 13%)',
-      borderRadius: 4 * theme.shape.borderRadius,
+    root: {
+      paddingBottom: theme.spacing(16.0),
     },
     header: {
       paddingLeft: 14,
       justifyContent: 'space-between',
+    },
+    paper: {
+      paddingBottom: theme.spacing(4.0),
     },
   });
 
@@ -40,6 +42,8 @@ let OwnerRepositoryList = (props: Props) => {
   let { classes, info } = props;
   let repositories = info.repositories.edges.map(edge => edge.node);
   let organizationSettings = null;
+  let pageWidth = usePageWidth();
+  let isNewDesign = pageWidth > 900;
 
   if (info && info.viewerPermission === 'ADMIN') {
     organizationSettings = (
@@ -53,9 +57,8 @@ let OwnerRepositoryList = (props: Props) => {
     );
   }
 
-  const isNewDesign = true;
   return (
-    <div>
+    <div className={classes.root}>
       <AppBreadcrumbs ownerName={info.name} platform={info.platform} />
       <Paper className={classes.paper}>
         <Toolbar className={classes.header} disableGutters>

--- a/src/components/account/OwnerRepositoryList.tsx
+++ b/src/components/account/OwnerRepositoryList.tsx
@@ -23,7 +23,7 @@ import Paper from '../common/Paper';
 let styles = theme =>
   createStyles({
     root: {
-      paddingBottom: theme.spacing(16.0),
+      paddingBottom: theme.spacing(15.0),
     },
     header: {
       paddingLeft: 14,

--- a/src/components/account/OwnerRepositoryList.tsx
+++ b/src/components/account/OwnerRepositoryList.tsx
@@ -38,7 +38,7 @@ interface Props extends WithStyles<typeof styles> {
 
 let OwnerRepositoryList = (props: Props) => {
   let { classes, info } = props;
-
+  let repositories = info.repositories.edges.map(edge => edge.node);
   let organizationSettings = null;
 
   if (info && info.viewerPermission === 'ADMIN') {
@@ -54,7 +54,6 @@ let OwnerRepositoryList = (props: Props) => {
   }
 
   const isNewDesign = true;
-
   return (
     <div>
       <AppBreadcrumbs ownerName={info.name} platform={info.platform} />
@@ -64,12 +63,12 @@ let OwnerRepositoryList = (props: Props) => {
           {organizationSettings}
         </Toolbar>
         {isNewDesign ? (
-          <RepositoryTable />
+          <RepositoryTable repositories={repositories} />
         ) : (
           <Table style={{ tableLayout: 'auto' }}>
             <TableBody>
-              {info.repositories.edges.map(edge => (
-                <LastDefaultBranchBuildRow key={edge.node.id} repository={edge.node} />
+              {repositories.map(repository => (
+                <LastDefaultBranchBuildRow key={repository.id} repository={repository} />
               ))}
             </TableBody>
           </Table>
@@ -91,6 +90,7 @@ export default createFragmentContainer(withStyles(styles)(OwnerRepositoryList), 
           node {
             id
             ...LastDefaultBranchBuildRow_repository
+            ...RepositoryTable_repositories
           }
         }
       }

--- a/src/components/account/OwnerRepositoryList.tsx
+++ b/src/components/account/OwnerRepositoryList.tsx
@@ -17,12 +17,18 @@ import { graphql } from 'babel-plugin-relay/macro';
 import { OwnerRepositoryList_info } from './__generated__/OwnerRepositoryList_info.graphql';
 import AppBreadcrumbs from '../../components/common/AppBreadcrumbs';
 import createStyles from '@mui/styles/createStyles';
+import RepositoryTable from '../repositories/RepositoryTable';
 
 let styles = theme =>
   createStyles({
-    toolbar: {
+    paper: {
+      padding: theme.spacing(1.0, 2.5, 1.5),
+      boxShadow: '0 16px 52px rgb(0 0 0 / 13%)',
+      borderRadius: 4 * theme.shape.borderRadius,
+    },
+    header: {
       paddingLeft: 14,
-      background: theme.palette.action.disabledBackground,
+      justifyContent: 'space-between',
     },
   });
 
@@ -47,23 +53,27 @@ let OwnerRepositoryList = (props: Props) => {
     );
   }
 
+  const isNewDesign = true;
+
   return (
     <div>
       <AppBreadcrumbs ownerName={info.name} platform={info.platform} />
-      <Paper elevation={16}>
-        <Toolbar className={classes.toolbar} sx={{ justifyContent: 'space-between' }} disableGutters>
-          <Typography variant="h5" color="inherit">
-            Repositories
-          </Typography>
+      <Paper className={classes.paper}>
+        <Toolbar className={classes.header} disableGutters>
+          <Typography variant="h5">Repositories</Typography>
           {organizationSettings}
         </Toolbar>
-        <Table style={{ tableLayout: 'auto' }}>
-          <TableBody>
-            {info.repositories.edges.map(edge => (
-              <LastDefaultBranchBuildRow key={edge.node.id} repository={edge.node} />
-            ))}
-          </TableBody>
-        </Table>
+        {isNewDesign ? (
+          <RepositoryTable />
+        ) : (
+          <Table style={{ tableLayout: 'auto' }}>
+            <TableBody>
+              {info.repositories.edges.map(edge => (
+                <LastDefaultBranchBuildRow key={edge.node.id} repository={edge.node} />
+              ))}
+            </TableBody>
+          </Table>
+        )}
       </Paper>
     </div>
   );

--- a/src/components/account/ViewerBuildList.tsx
+++ b/src/components/account/ViewerBuildList.tsx
@@ -11,7 +11,6 @@ import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
 import TableRow from '@mui/material/TableRow';
-import Paper from '@mui/material/Paper';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 
@@ -22,8 +21,9 @@ import BuildChangeChip from '../chips/BuildChangeChip';
 import { navigateBuildHelper } from '../../utils/navigateHelper';
 import usePageWidth from '../../utils/usePageWidth';
 import { isBuildFinalStatus } from '../../utils/status';
-import BuildsTable from '../../components/builds/BuildsTable';
+import BuildTable from '../builds/BuildTable';
 import MarkdownTypography from '../common/MarkdownTypography';
+import Paper from '../common/Paper';
 import { ViewerBuildListRefetchQuery } from './__generated__/ViewerBuildListRefetchQuery.graphql';
 import { ViewerBuildList_viewer$key } from './__generated__/ViewerBuildList_viewer.graphql';
 
@@ -31,9 +31,6 @@ import { ViewerBuildList_viewer$key } from './__generated__/ViewerBuildList_view
 const styles = theme => ({
   paper: {
     marginTop: theme.spacing(4),
-    padding: theme.spacing(1.0, 2.5, 1.5),
-    boxShadow: '0 16px 52px rgb(0 0 0 / 13%)',
-    borderRadius: 4 * theme.shape.borderRadius,
   },
   header: {
     paddingLeft: 14,
@@ -80,7 +77,7 @@ function ViewerBuildList(props: Props) {
                 ...BuildBranchNameChip_build
                 ...BuildChangeChip_build
                 ...BuildStatusChip_build
-                ...BuildsTable_builds
+                ...BuildTable_builds
                 repository {
                   ...RepositoryNameChip_repository
                 }
@@ -140,7 +137,7 @@ function ViewerBuildList(props: Props) {
   }
 
   let buildsComponent = isNewDesign ? (
-    <BuildsTable builds={builds} />
+    <BuildTable builds={builds} />
   ) : (
     <Table style={{ tableLayout: 'auto' }}>
       <TableBody>{builds.map(build => buildItem(build))}</TableBody>

--- a/src/components/builds/BuildBranch.tsx
+++ b/src/components/builds/BuildBranch.tsx
@@ -1,0 +1,60 @@
+import { graphql } from 'babel-plugin-relay/macro';
+import { createFragmentContainer } from 'react-relay';
+
+import { Stack, Link } from '@mui/material';
+import { CallSplit } from '@mui/icons-material';
+import { createStyles, withStyles, WithStyles } from '@mui/styles';
+
+import { shorten } from '../../utils/text';
+import { absoluteLink } from '../../utils/link';
+
+import { BuildBranch_build } from './__generated__/BuildBranch_build.graphql';
+
+const styles = theme =>
+  createStyles({
+    root: {
+      width: '100%',
+    },
+    name: {
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+    },
+  });
+
+interface Props extends WithStyles<typeof styles> {
+  build: BuildBranch_build;
+  tinted?: boolean;
+}
+
+const BuildBranch = ({ classes, build, tinted = false }: Props) => {
+  const href = absoluteLink(build.repository.platform, build.repository.owner, build.repository.name, build.branch);
+  return (
+    <Stack className={classes.root} direction="row" alignItems="center" spacing={0.5}>
+      <CallSplit fontSize="inherit" />
+      <Link
+        className={classes.name}
+        href={href}
+        underline="hover"
+        noWrap
+        title={build.branch}
+        {...(tinted && { color: 'text.primary' })}
+      >
+        {shorten(build.branch)}
+      </Link>
+    </Stack>
+  );
+};
+
+export default createFragmentContainer(withStyles(styles)(BuildBranch), {
+  build: graphql`
+    fragment BuildBranch_build on Build {
+      id
+      branch
+      repository {
+        platform
+        owner
+        name
+      }
+    }
+  `,
+});

--- a/src/components/builds/BuildDuration.tsx
+++ b/src/components/builds/BuildDuration.tsx
@@ -1,0 +1,55 @@
+import { graphql } from 'babel-plugin-relay/macro';
+import { createFragmentContainer } from 'react-relay';
+
+import { Stack } from '@mui/material';
+import { AccessTime } from '@mui/icons-material';
+import { createStyles, withStyles, WithStyles } from '@mui/styles';
+
+import { formatDuration } from '../../utils/time';
+
+import { BuildDuration_build } from './__generated__/BuildDuration_build.graphql';
+
+const styles = theme =>
+  createStyles({
+    icon: {
+      color: theme.palette.text.secondary,
+      position: 'relative',
+      top: '-0.5px',
+    },
+    time: {
+      color: theme.palette.text.secondary,
+    },
+    noTime: {
+      paddingLeft: theme.spacing(0.5),
+      color: theme.palette.text.secondary,
+    },
+  });
+
+interface Props extends WithStyles<typeof styles> {
+  build: BuildDuration_build;
+}
+
+const BuildDuration = ({ classes, build }: Props) => {
+  const seconds = build.clockDurationInSeconds;
+  return (
+    <>
+      {seconds ? (
+        <Stack direction="row" alignItems="center" spacing={0.5}>
+          <AccessTime className={classes.icon} />
+          <span className={classes.time}>{formatDuration(seconds)}</span>
+        </Stack>
+      ) : (
+        <span className={classes.noTime}>—</span>
+      )}
+    </>
+  );
+};
+
+export default createFragmentContainer(withStyles(styles)(BuildDuration), {
+  build: graphql`
+    fragment BuildDuration_build on Build {
+      id
+      clockDurationInSeconds
+    }
+  `,
+});

--- a/src/components/builds/BuildHash.tsx
+++ b/src/components/builds/BuildHash.tsx
@@ -1,0 +1,43 @@
+import { graphql } from 'babel-plugin-relay/macro';
+import { createFragmentContainer } from 'react-relay';
+
+import { Stack } from '@mui/material';
+import { createStyles, withStyles, WithStyles } from '@mui/styles';
+import { Commit } from '@mui/icons-material';
+
+import { BuildHash_build } from './__generated__/BuildHash_build.graphql';
+
+const styles = theme =>
+  createStyles({
+    root: {
+      fontFamily: 'Courier',
+      color: theme.palette.text.secondary,
+      border: `1px solid ${theme.palette.divider}`,
+      borderRadius: 3 * theme.shape.borderRadius,
+      width: 'fit-content',
+      padding: '1px 5px',
+      '& *': { fontSize: '14px !important' },
+    },
+  });
+
+interface Props extends WithStyles<typeof styles> {
+  build: BuildHash_build;
+}
+
+const BuildHash = ({ classes, build }: Props) => {
+  return (
+    <Stack className={classes.root} direction="row" alignItems="center" spacing={0.5}>
+      <Commit fontSize="inherit" />
+      <span>{build.changeIdInRepo.substr(0, 7)}</span>
+    </Stack>
+  );
+};
+
+export default createFragmentContainer(withStyles(styles)(BuildHash), {
+  build: graphql`
+    fragment BuildHash_build on Build {
+      id
+      changeIdInRepo
+    }
+  `,
+});

--- a/src/components/builds/BuildPreview.tsx
+++ b/src/components/builds/BuildPreview.tsx
@@ -1,0 +1,77 @@
+import { graphql } from 'babel-plugin-relay/macro';
+import { createFragmentContainer } from 'react-relay';
+
+import { useTheme, Stack, Link } from '@mui/material';
+import { createStyles, withStyles, WithStyles } from '@mui/styles';
+import { EastOutlined } from '@mui/icons-material';
+
+import { absoluteLink } from '../../utils/link';
+import BuildStatusChipNew from '../chips/BuildStatusChipNew';
+import BuildHash from './BuildHash';
+import BuildBranch from './BuildBranch';
+import BuildDuration from './BuildDuration';
+
+import { BuildPreview_build } from './__generated__/BuildPreview_build.graphql';
+
+const styles = theme =>
+  createStyles({
+    commitName: {
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      marginLeft: theme.spacing(1),
+    },
+    branch: {
+      maxWidth: 200,
+    },
+    arrow: {
+      marginLeft: theme.spacing(1.5),
+      marginRight: theme.spacing(1.5),
+      color: theme.palette.text.disabled,
+    },
+  });
+
+interface Props extends WithStyles<typeof styles> {
+  build: BuildPreview_build;
+}
+
+const BuildPreview = ({ classes, build }: Props) => {
+  const theme = useTheme();
+  return (
+    <Stack>
+      <Stack direction="row" alignItems="center">
+        <BuildStatusChipNew status={build.status} mini />
+        <Link
+          className={classes.commitName}
+          href={absoluteLink('build', build.id)}
+          underline="hover"
+          title={build.changeMessageTitle}
+          noWrap
+        >
+          {build.changeMessageTitle}
+        </Link>
+        <EastOutlined className={classes.arrow} />
+        <div className={classes.branch}>
+          <BuildBranch build={build} tinted />
+        </div>
+      </Stack>
+      <Stack height={theme.spacing(1)} />
+      <Stack direction="row" alignItems="center" spacing={1.5}>
+        <BuildHash build={build} />
+        <BuildDuration build={build} />
+      </Stack>
+    </Stack>
+  );
+};
+
+export default createFragmentContainer(withStyles(styles)(BuildPreview), {
+  build: graphql`
+    fragment BuildPreview_build on Build {
+      id
+      status
+      changeMessageTitle
+      ...BuildHash_build
+      ...BuildBranch_build
+      ...BuildDuration_build
+    }
+  `,
+});

--- a/src/components/chips/BuildStatusChipNew.tsx
+++ b/src/components/chips/BuildStatusChipNew.tsx
@@ -6,9 +6,10 @@ import { BuildStatus } from './__generated__/BuildStatusChip_build.graphql';
 
 interface Props {
   status: BuildStatus;
+  mini?: boolean;
 }
 
-function BuildStatusChip({ status }: Props) {
+function BuildStatusChip({ status, mini = false }: Props) {
   const label =
     {
       CREATED: 'created',
@@ -28,15 +29,19 @@ function BuildStatusChip({ status }: Props) {
       ABORTED: 'warning',
     }[status] || 'error';
 
-  const icon =
+  const IconName =
     {
       TRIGGERED: 'play_circle_outlined',
       CREATED: 'cloud_circle_outlined',
       EXECUTING: 'play_circle_outlined',
       COMPLETED: 'check_circle_outlined',
       FAILED: 'error_outline_outlined',
-      ABORTED: <StopCircleOutlinedIcon />, // mui shows wrong icon with the name 'stop_circle_outlined'
+      ABORTED: StopCircleOutlinedIcon, // mui shows wrong icon with the name 'stop_circle_outlined'
     }[status] || 'error_outline_outlined';
+
+  if (mini) {
+    return typeof IconName === 'string' ? <Icon color={color}>{IconName}</Icon> : <IconName color={color} />;
+  }
 
   return (
     <Chip
@@ -44,7 +49,7 @@ function BuildStatusChip({ status }: Props) {
       color={color}
       size="small"
       variant="outlined"
-      icon={typeof status === 'string' ? <Icon>{icon}</Icon> : icon}
+      icon={typeof IconName === 'string' ? <Icon>{IconName}</Icon> : <IconName />}
       sx={{
         '& .MuiChip-iconSmall': {
           marginLeft: '5px',

--- a/src/components/common/Paper.tsx
+++ b/src/components/common/Paper.tsx
@@ -1,0 +1,24 @@
+import { ReactChild } from 'react';
+import { Paper as MuiPaper } from '@mui/material';
+import { createStyles, withStyles, WithStyles } from '@mui/styles';
+import cx from 'classnames';
+
+let styles = theme =>
+  createStyles({
+    paper: {
+      padding: theme.spacing(1.0, 2.5, 1.5),
+      boxShadow: '0 16px 52px rgb(0 0 0 / 13%)',
+      borderRadius: 4 * theme.shape.borderRadius,
+    },
+  });
+
+interface Props extends WithStyles<typeof styles> {
+  className?: string;
+  children: ReactChild | ReactChild[];
+}
+
+const Paper = ({ classes, className, children }: Props) => {
+  return <MuiPaper className={cx(className, classes.paper)}>{children}</MuiPaper>;
+};
+
+export default withStyles(styles)(Paper);

--- a/src/components/repositories/RepositoryBuildList.tsx
+++ b/src/components/repositories/RepositoryBuildList.tsx
@@ -3,13 +3,11 @@ import { useNavigate } from 'react-router-dom';
 import { createFragmentContainer, requestSubscription } from 'react-relay';
 import { graphql } from 'babel-plugin-relay/macro';
 import { Helmet as Head } from 'react-helmet';
-import cx from 'classnames';
 
 import { WithStyles } from '@mui/styles';
 import Box from '@mui/material/Box';
 import Link from '@mui/material/Link';
 import Table from '@mui/material/Table';
-import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
 import Toolbar from '@mui/material/Toolbar';
 import Tooltip from '@mui/material/Tooltip';
@@ -30,14 +28,15 @@ import { NodeOfConnection } from '../../utils/utility-types';
 import { navigateBuildHelper } from '../../utils/navigateHelper';
 import usePageWidth from '../../utils/usePageWidth';
 import environment from '../../createRelayEnvironment';
-import AppBreadcrumbs from '../../components/common/AppBreadcrumbs';
+import AppBreadcrumbs from '../common/AppBreadcrumbs';
 import BuildStatusChip from '../chips/BuildStatusChip';
 import CreateBuildDialog from '../builds/CreateBuildDialog';
 import BuildDurationsChart from '../builds/BuildDurationsChart';
 import BuildBranchNameChip from '../chips/BuildBranchNameChip';
 import BuildChangeChip from '../chips/BuildChangeChip';
 import MarkdownTypography from '../common/MarkdownTypography';
-import BuildsTable from '../../components/builds/BuildsTable';
+import BuildTable from '../builds/BuildTable';
+import Paper from '../common/Paper';
 
 import { RepositoryBuildList_repository } from './__generated__/RepositoryBuildList_repository.graphql';
 
@@ -47,11 +46,6 @@ const styles = theme => ({
     paddingBottom: theme.spacing(16.0),
   },
   paper: {
-    padding: theme.spacing(1.0, 2.5, 1.5),
-    boxShadow: '0 16px 52px rgb(0 0 0 / 13%)',
-    borderRadius: 4 * theme.shape.borderRadius,
-  },
-  paperBuildsTable: {
     paddingBottom: theme.spacing(4.0),
   },
   header: {
@@ -156,7 +150,7 @@ function RepositoryBuildList(props: Props) {
 
   if (props.branch && builds.length > 5) {
     buildsChart = (
-      <Paper className={classes.paper} sx={{ mb: 2 }}>
+      <Paper>
         <Toolbar className={classes.header} disableGutters>
           <Typography variant="h5" color="inherit">
             Duration Chart
@@ -229,7 +223,7 @@ function RepositoryBuildList(props: Props) {
       {buildsChart}
 
       {/* BUILDS TABLE */}
-      <Paper className={cx(classes.paper, classes.paperBuildsTable)}>
+      <Paper className={classes.paper}>
         <Toolbar className={classes.header} disableGutters>
           <Stack direction="row" alignItems="center">
             <Typography variant="h5" color="inherit">
@@ -244,7 +238,7 @@ function RepositoryBuildList(props: Props) {
           </div>
         </Toolbar>
         {isNewDesign ? (
-          <BuildsTable builds={builds} selectedBuildId={selectedBuildId} setSelectedBuildId={setSelectedBuildId} />
+          <BuildTable builds={builds} selectedBuildId={selectedBuildId} setSelectedBuildId={setSelectedBuildId} />
         ) : (
           <Table style={{ tableLayout: 'auto' }}>
             <TableBody>{builds.map(build => buildItem(build))}</TableBody>
@@ -275,7 +269,7 @@ export default createFragmentContainer(withStyles(styles)(RepositoryBuildList), 
             clockDurationInSeconds
             durationInSeconds
             status
-            ...BuildsTable_builds
+            ...BuildTable_builds
             ...BuildBranchNameChip_build
             ...BuildChangeChip_build
             ...BuildStatusChip_build

--- a/src/components/repositories/RepositoryBuildList.tsx
+++ b/src/components/repositories/RepositoryBuildList.tsx
@@ -43,9 +43,9 @@ import { RepositoryBuildList_repository } from './__generated__/RepositoryBuildL
 // todo: move custom values to mui theme adjustments
 const styles = theme => ({
   root: {
-    paddingBottom: theme.spacing(16.0),
+    paddingBottom: theme.spacing(15.0),
   },
-  paper: {
+  TablePaper: {
     paddingBottom: theme.spacing(4.0),
   },
   header: {
@@ -61,6 +61,9 @@ const styles = theme => ({
   cell: {
     width: '100%',
     maxWidth: '600px',
+  },
+  buildsChartPaper: {
+    marginBottom: theme.spacing(1.5),
   },
   buildsChart: {
     height: 150,
@@ -150,7 +153,7 @@ function RepositoryBuildList(props: Props) {
 
   if (props.branch && builds.length > 5) {
     buildsChart = (
-      <Paper>
+      <Paper className={classes.buildsChartPaper}>
         <Toolbar className={classes.header} disableGutters>
           <Typography variant="h5" color="inherit">
             Duration Chart
@@ -223,7 +226,7 @@ function RepositoryBuildList(props: Props) {
       {buildsChart}
 
       {/* BUILDS TABLE */}
-      <Paper className={classes.paper}>
+      <Paper className={classes.TablePaper}>
         <Toolbar className={classes.header} disableGutters>
           <Stack direction="row" alignItems="center">
             <Typography variant="h5" color="inherit">

--- a/src/components/repositories/RepositoryTable.tsx
+++ b/src/components/repositories/RepositoryTable.tsx
@@ -1,0 +1,5 @@
+const RepositoryTable = () => {
+  return <div>Table</div>;
+};
+
+export default RepositoryTable;

--- a/src/components/repositories/RepositoryTable.tsx
+++ b/src/components/repositories/RepositoryTable.tsx
@@ -7,7 +7,7 @@ import { createFragmentContainer } from 'react-relay';
 
 import { createTheme } from '@mui/material/styles';
 import { createStyles, withStyles, WithStyles } from '@mui/styles';
-import { Stack, Table, TableRow, TableHead, TableBody, TableCell, Typography } from '@mui/material';
+import { Table, TableRow, TableHead, TableBody, TableCell, Typography } from '@mui/material';
 
 import { muiThemeOptions } from '../../cirrusTheme';
 import { navigateRepositoryHelper } from '../../utils/navigateHelper';

--- a/src/components/repositories/RepositoryTable.tsx
+++ b/src/components/repositories/RepositoryTable.tsx
@@ -21,12 +21,12 @@ const styles = () =>
     row: {
       cursor: 'pointer',
     },
-    cellRepository: {},
-    cellLastBuild: {
-      width: '600px',
-      maxWidth: '600px',
-      minWidth: '600px',
+    cellRepository: {
+      width: '250px',
+      maxWidth: '250px',
+      minWidth: '250px',
     },
+    cellLastBuild: {},
   });
 
 const styled = withStyles(styles);
@@ -60,7 +60,7 @@ interface HeadRowProps extends WithStyles<typeof styles> {}
 const HeadRow = styled(({ classes }: HeadRowProps) => {
   return (
     <TableRow>
-      <TableCell className={classes.cellRepository}>Repository</TableCell>
+      <TableCell className={classes.cellRepository}>Name</TableCell>
       <TableCell className={classes.cellLastBuild}>Last Build</TableCell>
     </TableRow>
   );

--- a/src/components/repositories/RepositoryTable.tsx
+++ b/src/components/repositories/RepositoryTable.tsx
@@ -1,5 +1,80 @@
-const RepositoryTable = () => {
-  return <div>Table</div>;
-};
+import { useMemo } from 'react';
+import { useRecoilValue } from 'recoil';
+import { ThemeProvider } from '@emotion/react';
+
+import { useTheme } from '@mui/material';
+import { createTheme } from '@mui/material/styles';
+import withStyles from '@mui/styles/withStyles';
+import createStyles from '@mui/styles/createStyles';
+import { WithStyles } from '@mui/styles';
+import Table from '@mui/material/Table';
+import TableRow from '@mui/material/TableRow';
+import TableHead from '@mui/material/TableHead';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+
+import { muiThemeOptions } from '../../cirrusTheme';
+
+// todo: move custom values to mui theme adjustments
+const styles = theme =>
+  createStyles({
+    table: {
+      tableLayout: 'auto',
+    },
+    cell: {
+      fontSize: 16,
+      whiteSpace: 'nowrap',
+      textOverflow: 'ellipsis',
+      '& *': {
+        fontSize: '16px !important',
+      },
+    },
+  });
+
+const styled = withStyles(styles);
+
+interface Props extends WithStyles<typeof styles> {}
+
+const RepositoryTable = styled(({ classes }: Props) => {
+  const themeOptions = useRecoilValue(muiThemeOptions);
+  const muiTheme = useMemo(() => createTheme(themeOptions), [themeOptions]);
+
+  return (
+    <ThemeProvider theme={muiTheme}>
+      <Table className={classes.table}>
+        <TableHead>
+          <HeadRow />
+        </TableHead>
+        <TableBody>
+          <RepositoryRow />
+        </TableBody>
+      </Table>
+    </ThemeProvider>
+  );
+});
+
+interface HeadRowProps extends WithStyles<typeof styles> {}
+
+const HeadRow = styled(({ classes }: HeadRowProps) => {
+  return (
+    <TableRow>
+      <TableCell className={classes.cell}>Repository</TableCell>
+      <TableCell className={classes.cell}>Last Build</TableCell>
+    </TableRow>
+  );
+});
+
+interface RepositoryRowProps extends WithStyles<typeof styles> {}
+
+const RepositoryRow = styled(({ classes }: RepositoryRowProps) => {
+  return (
+    <TableRow>
+      {/* REPOSITORY */}
+      <TableCell className={classes.cell}>Repository</TableCell>
+      {/* LAST BUILD */}
+      <TableCell className={classes.cell}>Last build</TableCell>
+    </TableRow>
+  );
+});
 
 export default RepositoryTable;


### PR DESCRIPTION
New components created: 
`<RepositoryTable> `
<img width="1135" alt="Screenshot 2022-12-26 at 16 56 34" src="https://user-images.githubusercontent.com/74831191/209565611-caba6a42-9f57-4eaf-b727-70ce4e1eeb05.png">

`<BuildPreview> `
<img width="234" alt="Screenshot 2022-12-26 at 16 53 01" src="https://user-images.githubusercontent.com/74831191/209565408-5b76e4e6-4378-44a0-a19b-0ada1ff3ec70.png">


`<Paper>` (with our custom styles)

Moved to reusable components (for using inside `<BuildTable>` and `<BuildPreview>`):
`<BuildBranch>`
`<BuildDuration>`
`<BuildHash>`

MuiTheme adjustment started:
MuiTableCell customised for table head and body

New state for `<BuildStatusChipNew>`:
mini (show icon without status text)
<img width="119" alt="Screenshot 2022-12-26 at 16 54 39" src="https://user-images.githubusercontent.com/74831191/209565486-06decd9e-b958-4828-b4d2-d2fa2e697697.png">
<img width="29" alt="Screenshot 2022-12-26 at 16 55 14" src="https://user-images.githubusercontent.com/74831191/209565515-f177d82f-e9d4-4388-9429-882bf98d75cc.png">
