### PR TITLE
Account selection in breadcrumbs

### DIFF
--- a/src/components/account/OwnerRepositoryList.tsx
+++ b/src/components/account/OwnerRepositoryList.tsx
@@ -15,6 +15,7 @@ import ManageAccountsIcon from '@mui/icons-material/ManageAccounts';
 import { createFragmentContainer } from 'react-relay';
 import { graphql } from 'babel-plugin-relay/macro';
 import { OwnerRepositoryList_info } from './__generated__/OwnerRepositoryList_info.graphql';
+import { OwnerRepositoryList_viewer } from './__generated__/OwnerRepositoryList_viewer.graphql';
 import AppBreadcrumbs from '../../components/common/AppBreadcrumbs';
 import createStyles from '@mui/styles/createStyles';
 
@@ -28,10 +29,11 @@ let styles = theme =>
 
 interface Props extends WithStyles<typeof styles> {
   info: OwnerRepositoryList_info;
+  viewer: OwnerRepositoryList_viewer;
 }
 
 let OwnerRepositoryList = (props: Props) => {
-  let { classes, info } = props;
+  let { classes, info, viewer } = props;
 
   let organizationSettings = null;
 
@@ -49,7 +51,7 @@ let OwnerRepositoryList = (props: Props) => {
 
   return (
     <div>
-      <AppBreadcrumbs ownerName={info.name} platform={info.platform} />
+      <AppBreadcrumbs ownerName={info.name} platform={info.platform} viewer={viewer} />
       <Paper elevation={16}>
         <Toolbar className={classes.toolbar} sx={{ justifyContent: 'space-between' }} disableGutters>
           <Typography variant="h5" color="inherit">
@@ -84,6 +86,11 @@ export default createFragmentContainer(withStyles(styles)(OwnerRepositoryList), 
           }
         }
       }
+    }
+  `,
+  viewer: graphql`
+    fragment OwnerRepositoryList_viewer on User {
+      ...AppBreadcrumbs_viewer
     }
   `,
 });

--- a/src/components/builds/BuildDetails.tsx
+++ b/src/components/builds/BuildDetails.tsx
@@ -32,6 +32,7 @@ import { BuildDetailsApproveBuildMutationVariables } from './__generated__/Build
 import { BuildDetailsReTriggerMutationVariables } from './__generated__/BuildDetailsReTriggerMutation.graphql';
 import { BuildDetailsReRunMutationVariables } from './__generated__/BuildDetailsReRunMutation.graphql';
 import { BuildDetailsCancelMutationVariables } from './__generated__/BuildDetailsCancelMutation.graphql';
+import { BuildDetails_viewer } from './__generated__/BuildDetails_viewer.graphql';
 import CommitMessage from '../common/CommitMessage';
 import AppBreadcrumbs from '../../components/common/AppBreadcrumbs';
 
@@ -119,6 +120,7 @@ const styles = () =>
 
 interface Props extends WithStyles<typeof styles> {
   build: BuildDetails_build;
+  viewer: BuildDetails_viewer;
 }
 
 function BuildDetails(props: Props) {
@@ -133,7 +135,7 @@ function BuildDetails(props: Props) {
       subscription.dispose();
     };
   }, [props.build.id]);
-  const { build, classes } = props;
+  const { build, viewer, classes } = props;
   const repository = build.repository;
 
   function approveBuild() {
@@ -287,6 +289,7 @@ function BuildDetails(props: Props) {
         branchName={build.branch}
         buildHash={build.changeIdInRepo.substr(0, 7)}
         buildId={build.id}
+        viewer={viewer}
       />
       <CirrusFavicon status={build.status} />
       <Head>
@@ -376,6 +379,11 @@ export default createFragmentContainer(withStyles(styles)(BuildDetails), {
         timestamp
         ...HookListRow_hook
       }
+    }
+  `,
+  viewer: graphql`
+    fragment BuildDetails_viewer on User {
+      ...AppBreadcrumbs_viewer
     }
   `,
 });

--- a/src/components/common/AppBreadcrumbs.tsx
+++ b/src/components/common/AppBreadcrumbs.tsx
@@ -1,8 +1,15 @@
 import * as React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { createFragmentContainer } from 'react-relay';
+import { graphql } from 'babel-plugin-relay/macro';
 
 import { WithStyles } from '@mui/styles';
 import Link from '@mui/material/Link';
+import Menu from '@mui/material/Menu';
+import Stack from '@mui/material/Stack';
+import Button from '@mui/material/Button';
 import SvgIcon from '@mui/material/SvgIcon';
+import MenuItem from '@mui/material/MenuItem';
 import withStyles from '@mui/styles/withStyles';
 import Typography from '@mui/material/Typography';
 import InputIcon from '@mui/icons-material/Input';
@@ -13,19 +20,13 @@ import createStyles from '@mui/styles/createStyles';
 import NavigateNextIcon from '@mui/icons-material/NavigateNext';
 import BookmarkBorderIcon from '@mui/icons-material/BookmarkBorder';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+import ButtonGroup from '@mui/material/ButtonGroup';
 
-import { absoluteLink } from '../../utils/link';
 import RepositoryIcon from './RepositoryIcon';
-import { IconButton } from '@mui/material';
-import cx from 'classnames';
-
-import Menu from '@mui/material/Menu';
-import MenuItem from '@mui/material/MenuItem';
-import { createFragmentContainer } from 'react-relay';
-import { graphql } from 'babel-plugin-relay/macro';
-import { AppBreadcrumbs_viewer } from './__generated__/AppBreadcrumbs_viewer.graphql';
+import { absoluteLink } from '../../utils/link';
 import { navigateHelper } from '../../utils/navigateHelper';
-import { useNavigate } from 'react-router-dom';
+
+import { AppBreadcrumbs_viewer } from './__generated__/AppBreadcrumbs_viewer.graphql';
 
 const styles = theme =>
   createStyles({
@@ -126,18 +127,20 @@ const AppBreadcrumbs = ({
 
   const crumbs = [owner, repository, branch, build, task, ...(extraCrumbs || [])].filter(Boolean);
   return (
-    <Breadcrumbs className={classes.root} separator={<NavigateNextIcon fontSize="small" />} aria-label="breadcrumb">
+    <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
       {viewer.relatedOwners && viewer.relatedOwners.length === 1 ? null : <AccountsCrumb viewer={viewer} />}
-      {crumbs.map((crumb, i) => (
-        <Crumb
-          key={crumb.name}
-          active={crumbs.length - 1 === i}
-          name={crumb.name}
-          href={crumb.href}
-          Icon={crumb.Icon}
-        />
-      ))}
-    </Breadcrumbs>
+      <Breadcrumbs className={classes.root} separator={<NavigateNextIcon fontSize="small" />} aria-label="breadcrumb">
+        {crumbs.map((crumb, i) => (
+          <Crumb
+            key={crumb.name}
+            active={crumbs.length - 1 === i}
+            name={crumb.name}
+            href={crumb.href}
+            Icon={crumb.Icon}
+          />
+        ))}
+      </Breadcrumbs>
+    </Stack>
   );
 };
 
@@ -165,10 +168,14 @@ const AccountsCrumb = styled(({ viewer, classes }: AccountsCrumbProps) => {
 
   return (
     <>
-      <button className={cx(classes.accountsCrumb, classes.crumb)} onClick={handleClick}>
-        Accounts
-        <ArrowDropDownIcon />
-      </button>
+      <ButtonGroup variant="contained">
+        <Button variant="contained" onClick={e => navigateHelper(navigate, e, '/settings/profile/')}>
+          Accounts
+        </Button>
+        <Button size="small" onClick={handleClick}>
+          <ArrowDropDownIcon />
+        </Button>
+      </ButtonGroup>
       <Menu
         id="basic-menu"
         anchorEl={anchorEl}

--- a/src/components/common/AppBreadcrumbs.tsx
+++ b/src/components/common/AppBreadcrumbs.tsx
@@ -20,7 +20,6 @@ import createStyles from '@mui/styles/createStyles';
 import NavigateNextIcon from '@mui/icons-material/NavigateNext';
 import BookmarkBorderIcon from '@mui/icons-material/BookmarkBorder';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
-import ButtonGroup from '@mui/material/ButtonGroup';
 
 import RepositoryIcon from './RepositoryIcon';
 import { absoluteLink } from '../../utils/link';
@@ -168,14 +167,10 @@ const AccountsCrumb = styled(({ viewer, classes }: AccountsCrumbProps) => {
 
   return (
     <>
-      <ButtonGroup variant="contained">
-        <Button variant="contained" onClick={e => navigateHelper(navigate, e, '/settings/profile/')}>
-          Accounts
-        </Button>
-        <Button size="small" onClick={handleClick}>
-          <ArrowDropDownIcon />
-        </Button>
-      </ButtonGroup>
+      <Button variant="contained" onClick={handleClick}>
+        Accounts
+        <ArrowDropDownIcon />
+      </Button>
       <Menu
         id="basic-menu"
         anchorEl={anchorEl}

--- a/src/components/metrics/RepositoryMetricsPage.tsx
+++ b/src/components/metrics/RepositoryMetricsPage.tsx
@@ -15,6 +15,7 @@ import MenuItem from '@mui/material/MenuItem';
 import Typography from '@mui/material/Typography';
 import Grid from '@mui/material/Grid';
 import { RepositoryMetricsPage_repository } from './__generated__/RepositoryMetricsPage_repository.graphql';
+import { RepositoryMetricsPage_viewer } from './__generated__/RepositoryMetricsPage_viewer.graphql';
 import { MetricsQueryParameters } from './__generated__/RepositoryMetricsChartsQuery.graphql';
 import { Helmet as Head } from 'react-helmet';
 import AppBreadcrumbs from '../../components/common/AppBreadcrumbs';
@@ -34,11 +35,12 @@ const styles = theme =>
 
 interface Props extends WithStyles<typeof styles> {
   repository: RepositoryMetricsPage_repository;
+  viewer: RepositoryMetricsPage_viewer;
 }
 
 function RepositoryMetricsPage(props: Props) {
   let [parameters, setParameters] = useState<MetricsQueryParameters>({});
-  let { repository, classes } = props;
+  let { repository, viewer, classes } = props;
 
   function handleChange(event) {
     setParameters({
@@ -53,6 +55,7 @@ function RepositoryMetricsPage(props: Props) {
         ownerName={repository.owner}
         platform={repository.platform}
         repositoryName={repository.name}
+        viewer={viewer}
         extraCrumbs={[
           {
             name: 'Metrics',
@@ -160,6 +163,11 @@ export default createFragmentContainer(withStyles(styles)(RepositoryMetricsPage)
       owner
       name
       platform
+    }
+  `,
+  viewer: graphql`
+    fragment RepositoryMetricsPage_viewer on User {
+      ...AppBreadcrumbs_viewer
     }
   `,
 });

--- a/src/components/repositories/RepositoryBuildList.tsx
+++ b/src/components/repositories/RepositoryBuildList.tsx
@@ -39,6 +39,7 @@ import BuildChangeChip from '../chips/BuildChangeChip';
 import MarkdownTypography from '../common/MarkdownTypography';
 import BuildsTable from '../../components/builds/BuildsTable';
 
+import { RepositoryBuildList_viewer } from './__generated__/RepositoryBuildList_viewer.graphql';
 import { RepositoryBuildList_repository } from './__generated__/RepositoryBuildList_repository.graphql';
 
 // todo: move custom values to mui theme adjustments
@@ -75,6 +76,7 @@ const styles = theme => ({
 
 interface Props extends WithStyles<typeof styles> {
   branch?: string;
+  viewer: RepositoryBuildList_viewer;
   repository: RepositoryBuildList_repository;
 }
 
@@ -218,6 +220,7 @@ function RepositoryBuildList(props: Props) {
         ownerName={repository.owner}
         repositoryName={repository.name}
         branchName={props.branch}
+        viewer={props.viewer}
       />
       <Head>
         <title>
@@ -282,6 +285,11 @@ export default createFragmentContainer(withStyles(styles)(RepositoryBuildList), 
           }
         }
       }
+    }
+  `,
+  viewer: graphql`
+    fragment RepositoryBuildList_viewer on User {
+      ...AppBreadcrumbs_viewer
     }
   `,
 });

--- a/src/components/repositories/RepositorySettingsPage.tsx
+++ b/src/components/repositories/RepositorySettingsPage.tsx
@@ -9,6 +9,7 @@ import { graphql } from 'babel-plugin-relay/macro';
 import { WithStyles } from '@mui/styles';
 import withStyles from '@mui/styles/withStyles';
 import { RepositorySettingsPage_repository } from './__generated__/RepositorySettingsPage_repository.graphql';
+import { RepositorySettingsPage_viewer } from './__generated__/RepositorySettingsPage_viewer.graphql';
 import RepositoryCronSettings from './RepositoryCronSettings';
 import { Link } from '@mui/material';
 import RepositoryDangerSettings from './RepositoryDangerSettings';
@@ -23,10 +24,11 @@ const styles = {
 
 interface Props extends WithStyles<typeof styles> {
   repository: RepositorySettingsPage_repository;
+  viewer: RepositorySettingsPage_viewer;
 }
 
 let RepositorySettingsPage = (props: Props) => {
-  let { classes, repository } = props;
+  let { classes, repository, viewer } = props;
 
   let link = (
     <Link color="inherit" href={`/${repository.platform}/${repository.owner}/${repository.name}`}>
@@ -39,6 +41,7 @@ let RepositorySettingsPage = (props: Props) => {
         ownerName={repository.owner}
         platform={repository.platform}
         repositoryName={repository.name}
+        viewer={viewer}
         extraCrumbs={[
           {
             name: 'Repository Settings',
@@ -83,6 +86,11 @@ export default createFragmentContainer(withStyles(styles)(RepositorySettingsPage
       ...RepositorySecuredVariables_repository
       ...RepositoryCronSettings_repository
       ...RepositoryDangerSettings_repository
+    }
+  `,
+  viewer: graphql`
+    fragment RepositorySettingsPage_viewer on User {
+      ...AppBreadcrumbs_viewer
     }
   `,
 });

--- a/src/components/settings/OwnerSettings.tsx
+++ b/src/components/settings/OwnerSettings.tsx
@@ -13,6 +13,7 @@ import OwnerApiSettings from './OwnerApiSettings';
 import OwnerSecuredVariables from './OwnerSecuredVariables';
 import OwnerPersistentWorkerPools from './OwnerPersistentWorkerPools';
 import { OwnerSettings_info } from './__generated__/OwnerSettings_info.graphql';
+import { OwnerSettings_viewer } from './__generated__/OwnerSettings_viewer.graphql';
 import MarkdownTypography from '../common/MarkdownTypography';
 import CardHeader from '@mui/material/CardHeader';
 import { Card, CardActions, CardContent } from '@mui/material';
@@ -32,10 +33,11 @@ const styles = theme =>
 
 interface Props extends WithStyles<typeof styles> {
   info: OwnerSettings_info;
+  viewer: OwnerSettings_viewer;
 }
 
 function OwnerSettings(props: Props) {
-  let { info, classes } = props;
+  let { info, viewer, classes } = props;
 
   if (!info) {
     return <Typography variant="subtitle1">Can't find information this organization!</Typography>;
@@ -50,6 +52,7 @@ function OwnerSettings(props: Props) {
       <AppBreadcrumbs
         ownerName={info.name}
         platform={info.platform}
+        viewer={viewer}
         extraCrumbs={[
           {
             name: 'Account Settings',
@@ -122,6 +125,11 @@ export default createFragmentContainer(withStyles(styles)(OwnerSettings), {
       ...OwnerSecuredVariables_info
       ...OwnerPersistentWorkerPools_info
       ...WebHookSettings_info
+    }
+  `,
+  viewer: graphql`
+    fragment OwnerSettings_viewer on User {
+      ...AppBreadcrumbs_viewer
     }
   `,
 });

--- a/src/components/tasks/TaskDetails.tsx
+++ b/src/components/tasks/TaskDetails.tsx
@@ -29,6 +29,7 @@ import TaskCommandList from './TaskCommandList';
 import TaskCommandsProgress from './TaskCommandsProgress';
 import TaskList from './TaskList';
 import { TaskDetails_task } from './__generated__/TaskDetails_task.graphql';
+import { TaskDetails_viewer } from './__generated__/TaskDetails_viewer.graphql';
 import {
   TaskDetailsReRunMutationResponse,
   TaskDetailsReRunMutationVariables,
@@ -175,6 +176,7 @@ const styles = theme =>
 
 interface Props extends WithStyles<typeof styles> {
   task: TaskDetails_task;
+  viewer: TaskDetails_viewer;
 }
 
 function TaskDetails(props: Props) {
@@ -192,7 +194,7 @@ function TaskDetails(props: Props) {
     return () => subscription.dispose();
   }, [props.task.id, props.task.status]);
 
-  let { task, classes } = props;
+  let { task, viewer, classes } = props;
   let build = task.build;
   let repository = task.repository;
 
@@ -505,6 +507,7 @@ function TaskDetails(props: Props) {
         buildId={build.id}
         taskName={task.name}
         taskId={task.id}
+        viewer={viewer}
       />
       <Head>
         <title>{task.name} - Cirrus CI</title>
@@ -689,6 +692,11 @@ export default createFragmentContainer(withStyles(styles)(TaskDetails), {
         locator
         trustedSecret
       }
+    }
+  `,
+  viewer: graphql`
+    fragment TaskDetails_viewer on User {
+      ...AppBreadcrumbs_viewer
     }
   `,
 });

--- a/src/scenes/Build/BuildById.tsx
+++ b/src/scenes/Build/BuildById.tsx
@@ -21,6 +21,9 @@ export default function BuildById(): JSX.Element {
           build(id: $buildId) {
             ...BuildDetails_build
           }
+          viewer {
+            ...BuildDetails_viewer
+          }
         }
       `}
       render={({ error, props }) => {
@@ -30,7 +33,7 @@ export default function BuildById(): JSX.Element {
         if (!props.build) {
           return <NotFound message={error} />;
         }
-        return <BuildDetails build={props.build} />;
+        return <BuildDetails viewer={props.viewer} build={props.build} />;
       }}
     />
   );

--- a/src/scenes/Build/BuildBySHA.tsx
+++ b/src/scenes/Build/BuildBySHA.tsx
@@ -23,6 +23,9 @@ export default function BuildBySHA() {
             branch
             ...BuildDetails_build
           }
+          viewer {
+            ...BuildDetails_viewer
+          }
         }
       `}
       render={({ error, props }) => {
@@ -38,7 +41,7 @@ export default function BuildBySHA() {
             return <BuildDetails build={build} />;
           }
         }
-        return <BuildDetails build={props.searchBuilds[0]} />;
+        return <BuildDetails viewer={props.viewer} build={props.searchBuilds[0]} />;
       }}
     />
   );

--- a/src/scenes/Owner/Owner.tsx
+++ b/src/scenes/Owner/Owner.tsx
@@ -21,6 +21,9 @@ export default function Owner(): JSX.Element {
           ownerInfoByName(platform: $platform, name: $owner) {
             ...OwnerRepositoryList_info
           }
+          viewer {
+            ...OwnerRepositoryList_viewer
+          }
         }
       `}
       render={({ error, props }) => {
@@ -30,7 +33,7 @@ export default function Owner(): JSX.Element {
         if (!props.ownerInfoByName) {
           return <NotFound />;
         }
-        return <OwnerRepositoryList info={props.ownerInfoByName} />;
+        return <OwnerRepositoryList viewer={props.viewer} info={props.ownerInfoByName} />;
       }}
     />
   );

--- a/src/scenes/Owner/OwnerSettingsRenderer.tsx
+++ b/src/scenes/Owner/OwnerSettingsRenderer.tsx
@@ -20,13 +20,16 @@ export default function OwnerSettingsRenderer(): JSX.Element {
           ownerInfoByName(platform: $platform, name: $name) {
             ...OwnerSettings_info
           }
+          viewer {
+            ...OwnerSettings_viewer
+          }
         }
       `}
       render={({ error, props }) => {
         if (!props) {
           return <CirrusLinearProgress />;
         }
-        return <OwnerSettings info={props.ownerInfoByName} />;
+        return <OwnerSettings viewer={props.viewer} info={props.ownerInfoByName} />;
       }}
     />
   );

--- a/src/scenes/Repository/OwnerRepository.tsx
+++ b/src/scenes/Repository/OwnerRepository.tsx
@@ -24,6 +24,9 @@ export default function OwnerRepository(): JSX.Element {
           ownerRepository(platform: $platform, owner: $owner, name: $name) {
             ...RepositoryBuildList_repository @arguments(branch: $branch)
           }
+          viewer {
+            ...RepositoryBuildList_viewer
+          }
         }
       `}
       render={({ error, props }) => {
@@ -40,7 +43,7 @@ export default function OwnerRepository(): JSX.Element {
           );
           return <NotFound messageComponent={notFoundMessage} />;
         }
-        return <RepositoryBuildList repository={props.ownerRepository} branch={branch} />;
+        return <RepositoryBuildList viewer={props.viewer} repository={props.ownerRepository} branch={branch} />;
       }}
     />
   );

--- a/src/scenes/RepositoryMetrics/RepositoryMetrics.tsx
+++ b/src/scenes/RepositoryMetrics/RepositoryMetrics.tsx
@@ -21,6 +21,9 @@ export default function RepositoryMetrics(parentProps): JSX.Element {
           ownerRepository(platform: $platform, owner: $owner, name: $name) {
             ...RepositoryMetricsPage_repository
           }
+          viewer {
+            ...RepositoryMetricsPage_viewer
+          }
         }
       `}
       render={({ error, props }) => {
@@ -30,7 +33,7 @@ export default function RepositoryMetrics(parentProps): JSX.Element {
         if (!props.ownerRepository) {
           return <NotFound message={error} />;
         }
-        return <RepositoryMetricsPage repository={props.ownerRepository} {...parentProps} />;
+        return <RepositoryMetricsPage viewer={props.viewer} repository={props.ownerRepository} {...parentProps} />;
       }}
     />
   );

--- a/src/scenes/RepositorySettings/RepositorySettings.tsx
+++ b/src/scenes/RepositorySettings/RepositorySettings.tsx
@@ -21,6 +21,9 @@ export default function RepositorySettings(): JSX.Element {
           repository(id: $repositoryId) {
             ...RepositorySettingsPage_repository
           }
+          viewer {
+            ...RepositorySettingsPage_viewer
+          }
         }
       `}
       render={({ error, props }) => {
@@ -30,7 +33,7 @@ export default function RepositorySettings(): JSX.Element {
         if (!props.repository) {
           return <NotFound message={error} />;
         }
-        return <RepositorySettingsPage repository={props.repository} />;
+        return <RepositorySettingsPage viewer={props.viewer} repository={props.repository} />;
       }}
     />
   );

--- a/src/scenes/Task/Task.tsx
+++ b/src/scenes/Task/Task.tsx
@@ -21,6 +21,9 @@ export default function Task(): JSX.Element {
           task(id: $taskId) {
             ...TaskDetails_task
           }
+          viewer {
+            ...TaskDetails_viewer
+          }
         }
       `}
       render={({ error, props }) => {
@@ -30,7 +33,7 @@ export default function Task(): JSX.Element {
         if (!props.task) {
           return <NotFound message={error} />;
         }
-        return <TaskDetails task={props.task} />;
+        return <TaskDetails viewer={props.viewer} task={props.task} />;
       }}
     />
   );


### PR DESCRIPTION
topic to discuss: The best way to get information on `relatedOwners` on pages where `Breadcrumbs` are used.
I have now expanded the query for each page to get `viewer` and use `viewer.relatedOwners`

