### PR TITLE
Use different icons for regular builds and tags in the new UI

### DIFF
--- a/src/components/builds/BuildsTable.tsx
+++ b/src/components/builds/BuildsTable.tsx
@@ -24,6 +24,7 @@ import CommitIcon from '@mui/icons-material/Commit';
 import Typography from '@mui/material/Typography';
 import createStyles from '@mui/styles/createStyles';
 import CallSplitIcon from '@mui/icons-material/CallSplit';
+import UnarchiveIcon from '@mui/icons-material/UnarchiveOutlined';
 
 import BuildStatusChipNew from '../chips/BuildStatusChipNew';
 import { muiThemeOptions } from '../../cirrusTheme';
@@ -275,7 +276,7 @@ const BuildRow = styled(
         {/* BRANCH */}
         <TableCell className={cx(classes.cell, classes.cellBranch)}>
           <Stack direction="row" alignItems="center" spacing={0.5}>
-            {build.tag ? <CommitIcon fontSize="inherit" /> : <CallSplitIcon fontSize="inherit" />}
+            {build.tag ? <UnarchiveIcon fontSize="inherit" /> : <CallSplitIcon fontSize="inherit" />}
             <Link
               className={classes.link}
               href={absoluteLink(

--- a/src/components/builds/BuildsTable.tsx
+++ b/src/components/builds/BuildsTable.tsx
@@ -275,7 +275,7 @@ const BuildRow = styled(
         {/* BRANCH */}
         <TableCell className={cx(classes.cell, classes.cellBranch)}>
           <Stack direction="row" alignItems="center" spacing={0.5}>
-            <CallSplitIcon fontSize="inherit" />
+            {build.tag ? <CommitIcon fontSize="inherit" /> : <CallSplitIcon fontSize="inherit" />}
             <Link
               className={classes.link}
               href={absoluteLink(
@@ -307,6 +307,7 @@ export default createFragmentContainer(BuildsTable, {
     fragment BuildsTable_builds on Build @relay(plural: true) {
       id
       branch
+      tag
       status
       changeIdInRepo
       changeMessageTitle


### PR DESCRIPTION
Similar to how it was with `BuildBranchNameChip` before.