### PR TITLE
Account button before the breadcrumbs

### DIFF
--- a/src/scenes/Build/BuildById.tsx
+++ b/src/scenes/Build/BuildById.tsx
@@ -23,6 +23,9 @@ export default function BuildById(): JSX.Element {
             ...BuildDetails_build
             ...AppBreadcrumbs_build
           }
+          viewer {
+            ...AppBreadcrumbs_viewer
+          }
         }
       `}
       render={({ error, props }) => {
@@ -34,7 +37,7 @@ export default function BuildById(): JSX.Element {
         }
         return (
           <>
-            <AppBreadcrumbs build={props.build} />
+            <AppBreadcrumbs build={props.build} viewer={props.viewer} />
             <BuildDetails build={props.build} />
           </>
         );

--- a/src/scenes/Build/BuildBySHA.tsx
+++ b/src/scenes/Build/BuildBySHA.tsx
@@ -25,6 +25,9 @@ export default function BuildBySHA() {
             ...BuildDetails_build
             ...AppBreadcrumbs_build
           }
+          viewer {
+            ...AppBreadcrumbs_viewer
+          }
         }
       `}
       render={({ error, props }) => {
@@ -42,7 +45,7 @@ export default function BuildBySHA() {
         }
         return (
           <>
-            <AppBreadcrumbs build={props.searchBuilds[0]} />
+            <AppBreadcrumbs build={props.searchBuilds[0]} viewer={props.viewer} />
             <BuildDetails build={props.searchBuilds[0]} />
           </>
         );

--- a/src/scenes/Owner/Owner.tsx
+++ b/src/scenes/Owner/Owner.tsx
@@ -23,6 +23,9 @@ export default function Owner(): JSX.Element {
             ...OwnerRepositoryList_info
             ...AppBreadcrumbs_info
           }
+          viewer {
+            ...AppBreadcrumbs_viewer
+          }
         }
       `}
       render={({ error, props }) => {
@@ -34,7 +37,7 @@ export default function Owner(): JSX.Element {
         }
         return (
           <>
-            <AppBreadcrumbs info={props.ownerInfoByName} />
+            <AppBreadcrumbs info={props.ownerInfoByName} viewer={props.viewer} />
             <OwnerRepositoryList info={props.ownerInfoByName} />;
           </>
         );

--- a/src/scenes/Owner/OwnerSettingsRenderer.tsx
+++ b/src/scenes/Owner/OwnerSettingsRenderer.tsx
@@ -23,6 +23,9 @@ export default function OwnerSettingsRenderer(): JSX.Element {
             ...OwnerSettings_info
             ...AppBreadcrumbs_info
           }
+          viewer {
+            ...AppBreadcrumbs_viewer
+          }
         }
       `}
       render={({ error, props }) => {
@@ -33,6 +36,7 @@ export default function OwnerSettingsRenderer(): JSX.Element {
           <>
             <AppBreadcrumbs
               info={props.ownerInfoByName}
+              viewer={props.viewer}
               extraCrumbs={[
                 {
                   name: 'Account Settings',

--- a/src/scenes/Repository/OwnerRepository.tsx
+++ b/src/scenes/Repository/OwnerRepository.tsx
@@ -26,6 +26,9 @@ export default function OwnerRepository(): JSX.Element {
             ...AppBreadcrumbs_repository
             ...RepositoryBuildList_repository @arguments(branch: $branch)
           }
+          viewer {
+            ...AppBreadcrumbs_viewer
+          }
         }
       `}
       render={({ error, props }) => {
@@ -44,7 +47,7 @@ export default function OwnerRepository(): JSX.Element {
         }
         return (
           <>
-            <AppBreadcrumbs repository={props.ownerRepository} branch={branch} />
+            <AppBreadcrumbs repository={props.ownerRepository} viewer={props.viewer} branch={branch} />
             <RepositoryBuildList repository={props.ownerRepository} branch={branch} />
           </>
         );

--- a/src/scenes/RepositoryMetrics/RepositoryMetrics.tsx
+++ b/src/scenes/RepositoryMetrics/RepositoryMetrics.tsx
@@ -24,6 +24,9 @@ export default function RepositoryMetrics(parentProps): JSX.Element {
             ...AppBreadcrumbs_repository
             ...RepositoryMetricsPage_repository
           }
+          viewer {
+            ...AppBreadcrumbs_viewer
+          }
         }
       `}
       render={({ error, props }) => {
@@ -37,6 +40,7 @@ export default function RepositoryMetrics(parentProps): JSX.Element {
           <>
             <AppBreadcrumbs
               repository={props.ownerRepository}
+              viewer={props.viewer}
               extraCrumbs={[
                 {
                   name: 'Metrics',

--- a/src/scenes/RepositorySettings/RepositorySettings.tsx
+++ b/src/scenes/RepositorySettings/RepositorySettings.tsx
@@ -24,6 +24,9 @@ export default function RepositorySettings(): JSX.Element {
             ...AppBreadcrumbs_repository
             ...RepositorySettingsPage_repository
           }
+          viewer {
+            ...AppBreadcrumbs_viewer
+          }
         }
       `}
       render={({ error, props }) => {
@@ -37,6 +40,7 @@ export default function RepositorySettings(): JSX.Element {
           <>
             <AppBreadcrumbs
               repository={props.repository}
+              viewer={props.viewer}
               extraCrumbs={[
                 {
                   name: 'Repository Settings',

--- a/src/scenes/Task/Task.tsx
+++ b/src/scenes/Task/Task.tsx
@@ -23,6 +23,9 @@ export default function Task(): JSX.Element {
             ...TaskDetails_task
             ...AppBreadcrumbs_task
           }
+          viewer {
+            ...AppBreadcrumbs_viewer
+          }
         }
       `}
       render={({ error, props }) => {
@@ -34,7 +37,7 @@ export default function Task(): JSX.Element {
         }
         return (
           <>
-            <AppBreadcrumbs task={props.task} />
+            <AppBreadcrumbs task={props.task} viewer={props.viewer} />
             <TaskDetails task={props.task} />
           </>
         );


### PR DESCRIPTION
Purpose: to make switching between accounts (organisations) easier for users who have more than 1 account (organisation). The new button allows you to switch when you are on any page where there are breadcrumbs