### PR TITLE
Disable React Router Navigation

### DIFF
--- a/src/utils/navigateHelper.ts
+++ b/src/utils/navigateHelper.ts
@@ -7,9 +7,9 @@ export function navigateHelper(navigate, event, url) {
 
   if (event && (event.metaKey || event.ctrlKey || event.button === 1 || event.button === 4)) {
     window.open(url, '_blank');
-  } else if (navigate && !url.includes('://')) {
+  } /*else if (navigate && !url.includes('://')) {
     navigate(url);
-  } else {
+  } */else {
     window.open(url, '_self');
   }
   if (event) {

--- a/src/utils/navigateHelper.ts
+++ b/src/utils/navigateHelper.ts
@@ -9,7 +9,7 @@ export function navigateHelper(navigate, event, url) {
     window.open(url, '_blank');
   } /*else if (navigate && !url.includes('://')) {
     navigate(url);
-  } */else {
+  } */ else {
     window.open(url, '_self');
   }
   if (event) {


### PR DESCRIPTION
It seems Relay is not playing nice with react router navigation. Lets temporary disable it until we figure out the right way to integrate these two frameworks.