### PR TITLE
prevent lineNumbers from appearing in selection when copying code

### DIFF
--- a/src/components/logs/InlineLogs.tsx
+++ b/src/components/logs/InlineLogs.tsx
@@ -29,6 +29,7 @@ const useStyles = makeStyles(theme => {
       width: '1%',
       minWidth: theme.spacing(5),
       textAlign: 'right',
+      userSelect: 'none',
     },
     lineContent: {
       fontFamily: 'Monaco, monospace',


### PR DESCRIPTION
before:
<img width="598" alt="image" src="https://github.com/cirruslabs/cirrus-ci-web/assets/1221897/ddb2a378-a033-4aff-9656-c9f950df8540">

after:
<img width="632" alt="image" src="https://github.com/cirruslabs/cirrus-ci-web/assets/1221897/aedc36c7-889e-4869-b9ea-16e63bf748e5">

Makes copying code from the UI cleaner.