### PR TITLE
Fixed labels

### DIFF
--- a/src/components/compute-credits/MonthlyUsageChart.tsx
+++ b/src/components/compute-credits/MonthlyUsageChart.tsx
@@ -10,6 +10,8 @@ import Switch from '@mui/material/Switch';
 import mui from '../../mui';
 import PlatformIcon from '../icons/PlatformIcon';
 import { MonthlyUsageChart_info$key } from './__generated__/MonthlyUsageChart_info.graphql';
+import Link from "@mui/material/Link";
+import Typography from "@mui/material/Typography";
 
 interface Props {
   info?: MonthlyUsageChart_info$key;
@@ -96,7 +98,7 @@ export default function MonthlyUsageChart(props: Props) {
   return (
     <mui.Card elevation={24}>
       <mui.CardHeader
-        title="Free Compute Monthly Usage"
+        title={<Typography variant="h5">Compute Monthly Usage of <Link href="https://cirrus-ci.org/guide/writing-tasks/#execution-environment">managed-by-us</Link> instances</Typography>}
         action={
           <mui.Stack direction="row" spacing={1} alignItems="center">
             <mui.Typography>Credits</mui.Typography>
@@ -121,7 +123,7 @@ export default function MonthlyUsageChart(props: Props) {
           </BarChart>
         </ResponsiveContainer>
         <mui.Typography variant="subtitle1">
-          <p>Chart above shows usage per platform of compute resources that Cirrus CI provides for free each month.</p>
+          <p>Chart above shows monthly usage per platform of compute resources on managed infrastructure.</p>
         </mui.Typography>
       </mui.CardContent>
     </mui.Card>

--- a/src/components/compute-credits/MonthlyUsageChart.tsx
+++ b/src/components/compute-credits/MonthlyUsageChart.tsx
@@ -5,13 +5,13 @@ import { graphql } from 'babel-plugin-relay/macro';
 import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 
 import { useTheme } from '@mui/material';
+import Link from '@mui/material/Link';
 import Switch from '@mui/material/Switch';
+import Typography from '@mui/material/Typography';
 
 import mui from '../../mui';
 import PlatformIcon from '../icons/PlatformIcon';
 import { MonthlyUsageChart_info$key } from './__generated__/MonthlyUsageChart_info.graphql';
-import Link from "@mui/material/Link";
-import Typography from "@mui/material/Typography";
 
 interface Props {
   info?: MonthlyUsageChart_info$key;
@@ -98,7 +98,12 @@ export default function MonthlyUsageChart(props: Props) {
   return (
     <mui.Card elevation={24}>
       <mui.CardHeader
-        title={<Typography variant="h5">Compute Monthly Usage of <Link href="https://cirrus-ci.org/guide/writing-tasks/#execution-environment">managed-by-us</Link> instances</Typography>}
+        title={
+          <Typography variant="h5">
+            Compute Monthly Usage of{' '}
+            <Link href="https://cirrus-ci.org/guide/writing-tasks/#execution-environment">managed-by-us</Link> instances
+          </Typography>
+        }
         action={
           <mui.Stack direction="row" spacing={1} alignItems="center">
             <mui.Typography>Credits</mui.Typography>


### PR DESCRIPTION
Initially these charts were showing only free usage but this didn't make sense, so we changed the data to be all the usage of the managed infrastructure. But the labels were not updated.