### PR TITLE
Add an option to strip timestamps when CIRRUS_LOG_TIMESTAMP is used

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@types/babel__preset-env": "^7.9.2",
     "@types/classnames": "^2.3.1",
     "@types/jest": "^29.5.1",
+    "@types/lodash": "^4.14.200",
     "@types/node": "^20.2.5",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/src/components/logs/Logs.tsx
+++ b/src/components/logs/Logs.tsx
@@ -45,6 +45,7 @@ const useStyles = makeStyles(theme => {
 interface Props {
   logsName: string;
   logs: string;
+  stripTimestamps?: boolean;
 }
 
 function Logs(props: Props) {
@@ -83,18 +84,27 @@ function Logs(props: Props) {
   let classes = useStyles();
   return (
     <div className={classes.logContainer}>
-      {props.logs.split('\n').map((line, index) => (
-        <div
-          id={'L' + index}
-          tabIndex={0} // to make it focusable
-          key={index}
-          className={classNames('log-line', classes.logLine, {
-            [classes.logLineHighlighted]: highLightedLineStart <= index && index <= highLightedLineEnd,
-          })}
-          onClick={e => selectLine(e, index)}
-          dangerouslySetInnerHTML={{ __html: ansiFormatter.ansi_to_html(line) }}
-        />
-      ))}
+      {props.logs.split('\n').map((line, index) => {
+        // Cirrus CI Agent uses exactly 15 characters for the timestamps[1]
+        //
+        // [1]: https://github.com/cirruslabs/cirrus-ci-agent/blob/a4bc09e4e8c8190158f5859854995d13fba3d335/internal/executor/logs.go#L85
+        if (props.stripTimestamps) {
+          line = line.slice(15);
+        }
+
+        return (
+          <div
+            id={'L' + index}
+            tabIndex={0} // to make it focusable
+            key={index}
+            className={classNames('log-line', classes.logLine, {
+              [classes.logLineHighlighted]: highLightedLineStart <= index && index <= highLightedLineEnd,
+            })}
+            onClick={e => selectLine(e, index)}
+            dangerouslySetInnerHTML={{ __html: ansiFormatter.ansi_to_html(line) }}
+          />
+        );
+      })}
     </div>
   );
 }

--- a/src/components/logs/Logs.tsx
+++ b/src/components/logs/Logs.tsx
@@ -86,9 +86,10 @@ function Logs(props: Props) {
     <div className={classes.logContainer}>
       {props.logs.split('\n').map((line, index) => {
         // Cirrus CI Agent uses exactly 15 characters for the timestamps[1]
+        // and they all start with a "[" prefix.
         //
         // [1]: https://github.com/cirruslabs/cirrus-ci-agent/blob/a4bc09e4e8c8190158f5859854995d13fba3d335/internal/executor/logs.go#L85
-        if (props.stripTimestamps) {
+        if (props.stripTimestamps && line.startsWith("[")) {
           line = line.slice(15);
         }
 

--- a/src/components/logs/Logs.tsx
+++ b/src/components/logs/Logs.tsx
@@ -89,7 +89,7 @@ function Logs(props: Props) {
         // and they all start with a "[" prefix.
         //
         // [1]: https://github.com/cirruslabs/cirrus-ci-agent/blob/a4bc09e4e8c8190158f5859854995d13fba3d335/internal/executor/logs.go#L85
-        if (props.stripTimestamps && line.startsWith("[")) {
+        if (props.stripTimestamps && line.startsWith('[')) {
           line = line.slice(15);
         }
 

--- a/src/components/tasks/TaskCommandList.tsx
+++ b/src/components/tasks/TaskCommandList.tsx
@@ -29,6 +29,7 @@ const useStyles = mui.makeStyles(theme => {
 
 interface Props {
   task: TaskCommandList_task$key;
+  stripTimestamps?: boolean;
 }
 
 export default function TaskCommandList(props: Props) {
@@ -125,7 +126,7 @@ export default function TaskCommandList(props: Props) {
           </mui.AccordionSummary>
           <mui.AccordionDetails className={classes.details}>
             <Suspense fallback={<CirrusCircularProgress />}>
-              <TaskCommandLogs taskId={task.id} command={command} />
+              <TaskCommandLogs taskId={task.id} command={command} stripTimestamps={props.stripTimestamps} />
             </Suspense>
           </mui.AccordionDetails>
         </mui.Accordion>

--- a/src/components/tasks/TaskCommandLogs.tsx
+++ b/src/components/tasks/TaskCommandLogs.tsx
@@ -48,6 +48,7 @@ interface RealTimeLogsProps {
   };
   initialLogLines: ReadonlyArray<string>;
   executionInfo: TaskCommandLogs_executionInfo$key;
+  stripTimestamps?: boolean;
 }
 
 function TaskCommandRealTimeLogs(props: RealTimeLogsProps) {
@@ -120,7 +121,7 @@ function TaskCommandRealTimeLogs(props: RealTimeLogsProps) {
   return (
     <div style={{ width: '100%', height: '100%' }}>
       {inProgress ? null : downloadButton}
-      <Logs logsName={command.name} logs={initialLogLines.join('\n') + additionalLogs} />
+      <Logs logsName={command.name} logs={initialLogLines.join('\n') + additionalLogs} stripTimestamps={props.stripTimestamps} />
       {inProgress ? <CirrusLinearProgress /> : null}
     </div>
   );
@@ -133,6 +134,7 @@ interface TaskCommandLogsProps {
     status: TaskCommandStatus;
     type: TaskCommandType;
   };
+  stripTimestamps?: boolean;
 }
 
 export default function TaskCommandLogs(props: TaskCommandLogsProps) {

--- a/src/components/tasks/TaskCommandLogs.tsx
+++ b/src/components/tasks/TaskCommandLogs.tsx
@@ -121,7 +121,11 @@ function TaskCommandRealTimeLogs(props: RealTimeLogsProps) {
   return (
     <div style={{ width: '100%', height: '100%' }}>
       {inProgress ? null : downloadButton}
-      <Logs logsName={command.name} logs={initialLogLines.join('\n') + additionalLogs} stripTimestamps={props.stripTimestamps} />
+      <Logs
+        logsName={command.name}
+        logs={initialLogLines.join('\n') + additionalLogs}
+        stripTimestamps={props.stripTimestamps}
+      />
       {inProgress ? <CirrusLinearProgress /> : null}
     </div>
   );

--- a/src/components/tasks/TaskDetails.tsx
+++ b/src/components/tasks/TaskDetails.tsx
@@ -8,6 +8,8 @@ import classNames from 'classnames';
 import environment from 'createRelayEnvironment';
 import mui from 'mui';
 
+import * as _ from "lodash";
+
 import TaskArtifacts from 'components/artifacts/TaskArtifacts';
 import TaskCancellerChip from 'components/chips/TaskCancellerChip';
 import TaskCreatedChip from 'components/chips/TaskCreatedChip';
@@ -95,6 +97,10 @@ const useStyles = mui.makeStyles(theme => {
     },
     transaction: {
       backgroundColor: theme.palette.success.light,
+    },
+    taskLogOptions: {
+      background: theme.palette.secondary.light,
+      padding: theme.spacing(2),
     },
     tabPanel: {
       padding: 0,
@@ -492,6 +498,29 @@ export default function TaskDetails(props: Props) {
     setDisplayDebugInfo(!displayDebugInfo);
   };
 
+  let taskLogOptions = <></>;
+
+  // Task log options
+  const [stripTimestamps, setStripTimestamps] = React.useState(false);
+
+  const cirrusLogTimestamp = _.some(task.labels, function (label) {
+    return _.isEqual(label.split(":"), ["CIRRUS_LOG_TIMESTAMP", "true"]);
+  })
+
+  if (cirrusLogTimestamp) {
+    const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+      setStripTimestamps(!event.target.checked);
+    };
+
+    taskLogOptions = <mui.Paper className={classes.taskLogOptions}>
+      <mui.FormGroup>
+        <mui.FormControlLabel control={
+          <mui.Checkbox checked={!stripTimestamps} onChange={onChange} />
+        } label="Display log timestamps" />
+      </mui.FormGroup>
+    </mui.Paper>;
+  }
+
   const tabbedCommandsAndHooks = (
     <mui.TabContext value={currentTab}>
       <mui.TabList onChange={handleChange}>
@@ -502,8 +531,9 @@ export default function TaskDetails(props: Props) {
         />
         <mui.Tab icon={<mui.icons.Functions />} label={'Hooks (' + task.hooks.length + ')'} value="hooks" />
       </mui.TabList>
+      {taskLogOptions}
       <mui.TabPanel value="instructions" className={classes.tabPanel}>
-        <TaskCommandList task={task} />
+        <TaskCommandList task={task} stripTimestamps={stripTimestamps} />
       </mui.TabPanel>
       <mui.TabPanel value="hooks" className={classes.tabPanel}>
         <HookList hooks={task.hooks} type={HookType.Task} />

--- a/src/components/tasks/TaskDetails.tsx
+++ b/src/components/tasks/TaskDetails.tsx
@@ -2,13 +2,12 @@ import React, { Suspense, useEffect, useMemo, useState } from 'react';
 import { requestSubscription, useFragment, useMutation } from 'react-relay';
 import { useLocation, useNavigate } from 'react-router-dom';
 
+import * as _ from 'lodash';
 import { graphql } from 'babel-plugin-relay/macro';
 import classNames from 'classnames';
 
 import environment from 'createRelayEnvironment';
 import mui from 'mui';
-
-import * as _ from "lodash";
 
 import TaskArtifacts from 'components/artifacts/TaskArtifacts';
 import TaskCancellerChip from 'components/chips/TaskCancellerChip';
@@ -504,21 +503,24 @@ export default function TaskDetails(props: Props) {
   const [stripTimestamps, setStripTimestamps] = React.useState(false);
 
   const cirrusLogTimestamp = _.some(task.labels, function (label) {
-    return _.isEqual(label.split(":"), ["CIRRUS_LOG_TIMESTAMP", "true"]);
-  })
+    return _.isEqual(label.split(':'), ['CIRRUS_LOG_TIMESTAMP', 'true']);
+  });
 
   if (cirrusLogTimestamp) {
     const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
       setStripTimestamps(!event.target.checked);
     };
 
-    taskLogOptions = <mui.Paper className={classes.taskLogOptions}>
-      <mui.FormGroup>
-        <mui.FormControlLabel control={
-          <mui.Checkbox checked={!stripTimestamps} onChange={onChange} />
-        } label="Display log timestamps" />
-      </mui.FormGroup>
-    </mui.Paper>;
+    taskLogOptions = (
+      <mui.Paper className={classes.taskLogOptions}>
+        <mui.FormGroup>
+          <mui.FormControlLabel
+            control={<mui.Checkbox checked={!stripTimestamps} onChange={onChange} />}
+            label="Display log timestamps"
+          />
+        </mui.FormGroup>
+      </mui.Paper>
+    );
   }
 
   const tabbedCommandsAndHooks = (

--- a/src/mui.ts
+++ b/src/mui.ts
@@ -35,7 +35,7 @@ import ViewList from '@mui/icons-material/ViewList';
 import TabContext from '@mui/lab/TabContext';
 import TabList from '@mui/lab/TabList';
 import TabPanel from '@mui/lab/TabPanel';
-import { useTheme } from '@mui/material';
+import {FormGroup, useTheme} from '@mui/material';
 import Accordion from '@mui/material/Accordion';
 import AccordionDetails from '@mui/material/AccordionDetails';
 import AccordionSummary from '@mui/material/AccordionSummary';
@@ -137,6 +137,7 @@ const mui = {
   Divider,
   Drawer,
   Fab,
+  FormGroup,
   FormControl,
   FormControlLabel,
   FormHelperText,

--- a/src/mui.ts
+++ b/src/mui.ts
@@ -35,7 +35,7 @@ import ViewList from '@mui/icons-material/ViewList';
 import TabContext from '@mui/lab/TabContext';
 import TabList from '@mui/lab/TabList';
 import TabPanel from '@mui/lab/TabPanel';
-import {FormGroup, useTheme} from '@mui/material';
+import { FormGroup, useTheme } from '@mui/material';
 import Accordion from '@mui/material/Accordion';
 import AccordionDetails from '@mui/material/AccordionDetails';
 import AccordionSummary from '@mui/material/AccordionSummary';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5748,6 +5748,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/lodash@npm:^4.14.200":
+  version: 4.14.200
+  resolution: "@types/lodash@npm:4.14.200"
+  checksum: 6471f8bb5da692a6ecf03a8da4935bfbc341e67ee9bcb4f5730bfacff0c367232548f0a01e8ac5ea18c6fe78fb085d502494e33ccb47a7ee87cbdee03b47d00d
+  languageName: node
+  linkType: hard
+
 "@types/mdast@npm:^3.0.0, @types/mdast@npm:^3.0.3":
   version: 3.0.10
   resolution: "@types/mdast@npm:3.0.10"
@@ -7749,6 +7756,7 @@ __metadata:
     "@types/classnames": ^2.3.1
     "@types/google-protobuf": ^3.15.6
     "@types/jest": ^29.5.1
+    "@types/lodash": ^4.14.200
     "@types/node": ^20.2.5
     "@types/react": ^18
     "@types/react-dom": ^18


### PR DESCRIPTION
Looks like this by default for tasks that use `CIRRUS_LOG_TIMESTAMP`:

<img width="1161" alt="Screenshot 2023-10-31 at 17 09 28" src="https://github.com/cirruslabs/cirrus-ci-web/assets/85709/45db7f3e-14ce-40e2-98fc-350cb29e623f">

Looks like this when toggled for tasks that use `CIRRUS_LOG_TIMESTAMP`:

<img width="1161" alt="Screenshot 2023-10-31 at 17 09 33" src="https://github.com/cirruslabs/cirrus-ci-web/assets/85709/24843c78-c98a-4f2e-9221-ffc2751657d4">

Not displayed for tasks that don't use `CIRRUS_LOG_TIMESTAMP`.

Resolves #581.