### PR TITLE
Fix dark theme for "Display log timestamps"

### DIFF
--- a/src/components/tasks/TaskDetails.tsx
+++ b/src/components/tasks/TaskDetails.tsx
@@ -99,7 +99,7 @@ const useStyles = mui.makeStyles(theme => {
       backgroundColor: theme.palette.success.light,
     },
     taskLogOptions: {
-      background: theme.palette.secondary.light,
+      background: theme.palette.mode === 'dark' ? theme.palette.secondary.dark : theme.palette.secondary.light,
       padding: theme.spacing(2),
     },
     tabPanel: {


### PR DESCRIPTION
Looks like this now:

<img width="1188" alt="Screenshot 2023-11-21 at 00 33 54" src="https://github.com/cirruslabs/cirrus-ci-web/assets/85709/f0539bb4-1241-4c9b-a359-0c3abbd6b5d1">