### PR TITLE
Better differentiate branches and tags

### DIFF
--- a/src/components/chips/BuildBranchNameChipNew.tsx
+++ b/src/components/chips/BuildBranchNameChipNew.tsx
@@ -73,14 +73,14 @@ export default function BuildBranchNameChipNew(props: Props) {
     <div className={props.withHeader ? classes.container : ''}>
       {props.withHeader && (
         <Typography variant="caption" color={theme.palette.text.disabled} lineHeight={1}>
-          Branch
+          {build.tag ? 'Tag' : 'Branch'}
         </Typography>
       )}
       {build.tag ? (
-        <Tooltip title={`${build.tag} tag`}>
+        <Tooltip title={`On ${build.branch} branch`}>
           <Chip
             className={cx(props.className, classes.chip)}
-            label={shorten(build.branch)}
+            label={build.tag}
             avatar={<UnarchiveIcon />}
             size="small"
             onClick={handleBranchClick}


### PR DESCRIPTION
Problem: when making a release, two builds are usually created, and it's hard to tell which of the builds will be the one having `$CIRRUS_TAG`, and thus, likely, a release task, which one might want to check on:

<img width="1171" alt="Screenshot 2023-11-30 at 21 37 20" src="https://github.com/cirruslabs/cirrus-ci-web/assets/85709/e007cde1-a0db-41df-a80c-7f39aee55837">

On the screenshot above, the only difference is the icon, and the icon name is `UnarchiveIcon`, which is kinda makes no sense.

Changing just the icon helps things a bit, but introduces some weirdness, because now have a *tag* signifier next to a *branch* name:

<img width="1171" alt="Screenshot 2023-11-30 at 21 45 40" src="https://github.com/cirruslabs/cirrus-ci-web/assets/85709/80219410-81c2-4259-8d0f-844d8eb8b575">

What works, though, IMO, is actually displaying the tag (when there's one), and this is what this PR does:

<img width="1171" alt="Screenshot 2023-11-30 at 21 37 35" src="https://github.com/cirruslabs/cirrus-ci-web/assets/85709/f789e486-4c5c-4897-801f-e8fde0be7654">

Now, it doesn't even matter which icon we'd pick, it's pretty evident what kind of Git reference we're dealing with.