### PR TITLE
Cache Tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ EXPOSE 8080
 COPY --from=builder /tmp/cirrus-ci-web/serve.json /svc/cirrus-ci-web/serve.json
 COPY --from=builder /tmp/cirrus-ci-web/build/ /svc/cirrus-ci-web/
 
-RUN npm install -g serve@14.1.2
+RUN npm install -g serve@14.2.1
 
 CMD serve --single \
           --listen 8080 \

--- a/serve.json
+++ b/serve.json
@@ -9,7 +9,7 @@
         },
         {
           "key": "Cache-Control",
-          "value": "public,max-age=3600"
+          "value": "public"
         },
         {
           "key": "Strict-Transport-Security",
@@ -30,7 +30,7 @@
       ]
     },
     {
-      "source": "**/*.@(jpg|jpeg|gif|png|js|css)",
+      "source": "**/*.@(jpg|jpeg|gif|png|svg|ico|js|css|txt|json)",
       "headers": [
         {
           "key": "Vary",


### PR DESCRIPTION
When rolling out a new deployment requests like `/static/js/6848.e511c8953423.chunk.js` cab point to the default 200 of the `index.html` since it's an SPA. Then CDN cache cache it up for an hour which can break things.

This change disables caching by default and makes sure only static assets are actually cached.

Note that `serve` still returns `etag` so `index.html` will be "cached" but without a TTL.