### PR TITLE
Allow to trigger only paused manual tasks

### DIFF
--- a/src/components/tasks/TaskDetails.tsx
+++ b/src/components/tasks/TaskDetails.tsx
@@ -426,7 +426,7 @@ export default function TaskDetails(props: Props) {
       </>
     );
 
-  let taskIsTriggerable = task.status === 'PAUSED';
+  let taskIsTriggerable = task.status === 'PAUSED' && task.triggerType === 'MANUAL';
   let taskIsPreTriggerable = task.status === 'CREATED' && task.triggerType === 'MANUAL';
   let triggerButton =
     !hasWritePermissions(build.viewerPermission) || !taskIsTriggerable ? null : (


### PR DESCRIPTION
To prevent scenarios where one can trigger `bar` without dependencies in the following example:

```yaml
foo_task:
  trigger_type: manual
  script: exit 0

bar_task:
  depends_on: foo
  script: exit 0
```