### PR TITLE
Prevent "cannot read properties of undefined (reading 'data')" errors

### DIFF
--- a/src/createRelayEnvironment.ts
+++ b/src/createRelayEnvironment.ts
@@ -77,9 +77,10 @@ async function fetchQuery(operation: RequestParameters, variables) {
       body: JSON.stringify(query),
     });
     transaction.setHttpStatus(response.status);
-    return response.json();
+    return await response.json();
   } catch (e) {
     transaction.setStatus(SpanStatus.InternalError);
+    throw e;
   } finally {
     transaction.finish();
   }


### PR DESCRIPTION
Problem: currently we pass the `json()` promise to Relay, but this promise might as well turn into undefined if there's no JSON data in the response.

Solution: await on the json() before returning and propagate the exception if one is caught.

Related Sentry issue: `CIRRUS-CI-WEB-AK`.