### PR TITLE
More granular error boundaries

### DIFF
--- a/src/AllRoutes.tsx
+++ b/src/AllRoutes.tsx
@@ -15,6 +15,9 @@ import GitHubStatus from 'components/status/GitHubStatus';
 import ActiveRepositoriesDrawer from 'scenes/Header/ActiveRepositoriesDrawer';
 import ViewerTopRepositories from 'scenes/Profile/ViewerTopRepositories';
 
+import StatusFallback from './components/status/StatusFallback';
+import ActiveRepositoriesFallback from './scenes/Header/ActiveRepositoriesDrawerFallback';
+
 const AsyncViewerProfile = React.lazy(() => import('scenes/Profile/ViewerProfile'));
 
 const AsyncHome = React.lazy(() => import('scenes/Home/Home'));
@@ -170,9 +173,11 @@ function AllRoutes() {
           <mui.icons.Close />
         </mui.IconButton>
       </mui.Stack>
-      <Suspense fallback={<CirrusLinearProgress />}>
-        <ViewerTopRepositories className={classes.topRepositories} />
-      </Suspense>
+      <Sentry.ErrorBoundary fallback={<CirrusLinearProgress />}>
+        <Suspense fallback={<CirrusLinearProgress />}>
+          <ViewerTopRepositories className={classes.topRepositories} />
+        </Suspense>
+      </Sentry.ErrorBoundary>
     </mui.Stack>
   );
 
@@ -242,12 +247,16 @@ function AllRoutes() {
               </mui.Typography>
             </Link>
             <div className={classes.flex} />
-            <Suspense fallback={<div />}>
-              <GCPStatus />
-            </Suspense>
-            <Suspense fallback={<div />}>
-              <GitHubStatus />
-            </Suspense>
+            <Sentry.ErrorBoundary fallback={<StatusFallback />}>
+              <Suspense fallback={<StatusFallback />}>
+                <GCPStatus />
+              </Suspense>
+            </Sentry.ErrorBoundary>
+            <Sentry.ErrorBoundary fallback={<StatusFallback />}>
+              <Suspense fallback={<StatusFallback />}>
+                <GitHubStatus />
+              </Suspense>
+            </Sentry.ErrorBoundary>
             <ThemeSwitchButton />
             <mui.Tooltip sx={{ display: { xs: 'none', sm: 'block' } }} title="Go to front-end source repository">
               <mui.IconButton
@@ -272,9 +281,11 @@ function AllRoutes() {
               </mui.IconButton>
             </mui.Tooltip>
             <div className={classes.marginRight}>
-              <Suspense fallback={<CirrusLinearProgress />}>
-                <ActiveRepositoriesDrawer />
-              </Suspense>
+              <Sentry.ErrorBoundary fallback={<ActiveRepositoriesFallback />}>
+                <Suspense fallback={<ActiveRepositoriesFallback />}>
+                  <ActiveRepositoriesDrawer />
+                </Suspense>
+              </Sentry.ErrorBoundary>
             </div>
           </mui.Toolbar>
         </mui.AppBar>
@@ -287,27 +298,29 @@ function AllRoutes() {
         >
           <div className={classNames('invisible', classes.drawerHeader)} />
           <mui.Container maxWidth={openDrawer ? false : 'lg'}>
-            <Suspense fallback={<CirrusLinearProgress />}>
-              <SentryRoutes>
-                <Route path="/" element={<AsyncHome />} />
-                <Route path="explorer" element={<AsyncApiExplorerRenderer />} />
-                <Route path="settings/profile" element={<AsyncViewerProfile />} />
-                <Route path="settings/:platform/:name" element={<AsyncOwnerSettingsRenderer />} />
-                <Route path="settings/repository/:repositoryId" element={<AsyncRepositorySettings />} />
-                <Route path="build/:buildId" element={<AsyncBuildById />} />
-                <Route path="build/:owner/:name/:SHA" element={<AsyncBuildBySHA />} />
-                <Route path=":platform/:owner/:name/*" element={<AsyncOwnerRepository />} />
-                <Route path=":platform/:owner/:name" element={<AsyncOwnerRepository />} />
-                <Route path=":platform/:owner" element={<AsyncOwner />} />
-                <Route path="repository/:repositoryId/*" element={<AsyncRepository />} />
-                <Route path="repository/:repositoryId" element={<AsyncRepository />} />
-                <Route path="metrics/repository/:platform/:owner/:name" element={<AsyncRepositoryMetrics />} />
-                <Route path="task/:taskId" element={<AsyncTask />} />
-                <Route path="task/:taskId/hooks" element={<AsyncTask />} />
-                <Route path="pool/:poolId" element={<AsyncPoolById />} />
-                <Route path="hook/:hookId" element={<AsyncHook />} />
-              </SentryRoutes>
-            </Suspense>
+            <Sentry.ErrorBoundary fallback={<CirrusLinearProgress />}>
+              <Suspense fallback={<CirrusLinearProgress />}>
+                <SentryRoutes>
+                  <Route path="/" element={<AsyncHome />} />
+                  <Route path="explorer" element={<AsyncApiExplorerRenderer />} />
+                  <Route path="settings/profile" element={<AsyncViewerProfile />} />
+                  <Route path="settings/:platform/:name" element={<AsyncOwnerSettingsRenderer />} />
+                  <Route path="settings/repository/:repositoryId" element={<AsyncRepositorySettings />} />
+                  <Route path="build/:buildId" element={<AsyncBuildById />} />
+                  <Route path="build/:owner/:name/:SHA" element={<AsyncBuildBySHA />} />
+                  <Route path=":platform/:owner/:name/*" element={<AsyncOwnerRepository />} />
+                  <Route path=":platform/:owner/:name" element={<AsyncOwnerRepository />} />
+                  <Route path=":platform/:owner" element={<AsyncOwner />} />
+                  <Route path="repository/:repositoryId/*" element={<AsyncRepository />} />
+                  <Route path="repository/:repositoryId" element={<AsyncRepository />} />
+                  <Route path="metrics/repository/:platform/:owner/:name" element={<AsyncRepositoryMetrics />} />
+                  <Route path="task/:taskId" element={<AsyncTask />} />
+                  <Route path="task/:taskId/hooks" element={<AsyncTask />} />
+                  <Route path="pool/:poolId" element={<AsyncPoolById />} />
+                  <Route path="hook/:hookId" element={<AsyncHook />} />
+                </SentryRoutes>
+              </Suspense>
+            </Sentry.ErrorBoundary>
           </mui.Container>
         </main>
       </mui.Stack>

--- a/src/cirrusTheme.ts
+++ b/src/cirrusTheme.ts
@@ -92,6 +92,13 @@ export let cirrusLightTheme: ThemeOptions = {
         },
       },
     },
+    MuiSkeleton: {
+      styleOverrides: {
+        root: {
+          backgroundColor: grey['800'],
+        },
+      },
+    },
     MuiTableCell: {
       styleOverrides: {
         body: {

--- a/src/components/status/StatusFallback.tsx
+++ b/src/components/status/StatusFallback.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import { Skeleton, useTheme } from '@mui/material';
+
+export default function StatusFallback() {
+  let theme = useTheme();
+
+  return (
+    <Skeleton
+      variant={'circular'}
+      width={theme.spacing(3)}
+      height={theme.spacing(3)}
+      sx={{ margin: theme.spacing(1.5) }}
+    />
+  );
+}

--- a/src/components/tasks/TaskCommandList.tsx
+++ b/src/components/tasks/TaskCommandList.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react';
 import React, { Suspense } from 'react';
 import { useFragment } from 'react-relay';
 import { useLocation } from 'react-router-dom';
@@ -125,9 +126,11 @@ export default function TaskCommandList(props: Props) {
             </div>
           </mui.AccordionSummary>
           <mui.AccordionDetails className={classes.details}>
-            <Suspense fallback={<CirrusCircularProgress />}>
-              <TaskCommandLogs taskId={task.id} command={command} stripTimestamps={props.stripTimestamps} />
-            </Suspense>
+            <Sentry.ErrorBoundary fallback={<CirrusCircularProgress />}>
+              <Suspense fallback={<CirrusCircularProgress />}>
+                <TaskCommandLogs taskId={task.id} command={command} stripTimestamps={props.stripTimestamps} />
+              </Suspense>
+            </Sentry.ErrorBoundary>
           </mui.AccordionDetails>
         </mui.Accordion>
       </mui.Box>

--- a/src/components/tasks/TaskDetails.tsx
+++ b/src/components/tasks/TaskDetails.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react';
 import React, { Suspense, useEffect, useMemo, useState } from 'react';
 import { requestSubscription, useFragment, useMutation } from 'react-relay';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -707,9 +708,11 @@ export default function TaskDetails(props: Props) {
       {notificationsComponent}
       <mui.Collapse in={displayDebugInfo} unmountOnExit={true}>
         <div className={classes.gap} />
-        <Suspense fallback={<CirrusLinearProgress />}>
-          <TaskDebuggingInformation taskId={task.id} />
-        </Suspense>
+        <Sentry.ErrorBoundary fallback={<CirrusLinearProgress />}>
+          <Suspense fallback={<CirrusLinearProgress />}>
+            <TaskDebuggingInformation taskId={task.id} />
+          </Suspense>
+        </Sentry.ErrorBoundary>
       </mui.Collapse>
       <mui.Collapse in={shouldRunTerminal}>
         <div className={classes.gap} />

--- a/src/components/webhooks/DeliveryInfoDialog.tsx
+++ b/src/components/webhooks/DeliveryInfoDialog.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react';
 import React, { Suspense } from 'react';
 
 import Button from '@mui/material/Button/Button';
@@ -23,9 +24,11 @@ export default function DeliveryInfoDialog(props: Props) {
   return (
     <Dialog {...other}>
       <DialogTitle>Delivery Info for {delivery.id}</DialogTitle>
-      <Suspense fallback={<CirrusLinearProgress />}>
-        <DeliveryInfoDialogLazyContent deliveryId={delivery.id} />
-      </Suspense>
+      <Sentry.ErrorBoundary fallback={<CirrusLinearProgress />}>
+        <Suspense fallback={<CirrusLinearProgress />}>
+          <DeliveryInfoDialogLazyContent deliveryId={delivery.id} />
+        </Suspense>
+      </Sentry.ErrorBoundary>
       <DialogActions>
         <Button onClick={props.onClose} variant="contained" autoFocus>
           Close

--- a/src/scenes/Header/ActiveRepositoriesDrawerFallback.tsx
+++ b/src/scenes/Header/ActiveRepositoriesDrawerFallback.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import { Skeleton, useTheme } from '@mui/material';
+
+export default function ActiveRepositoriesFallback() {
+  let theme = useTheme();
+
+  return (
+    <Skeleton
+      variant={'circular'}
+      width={theme.spacing(5)}
+      height={theme.spacing(5)}
+      sx={{ margin: theme.spacing(1.5) }}
+    />
+  );
+}


### PR DESCRIPTION
Basically what this does is wraps every `<Suspense>` in an `<Sentry.ErrorBoundary>` with the same fallback as `<Suspense>` has.

The result is that the UI doesn't break and fall into a blank page on error, but keeps pulsating:

[<video src="">](https://github.com/cirruslabs/cirrus-ci-web/assets/85709/16f09721-4cfc-4408-9771-a71a47d51728)