### PR TITLE
Gray out only completed builds with paused tasks

### DIFF
--- a/src/components/chips/BuildStatusChipNew.tsx
+++ b/src/components/chips/BuildStatusChipNew.tsx
@@ -99,6 +99,9 @@ export default function BuildStatusChip(props: Props) {
 
   if (build.hasPausedTasks) {
     icon = 'pause_circle';
+  }
+
+  if (build.hasPausedTasks && build.status === 'COMPLETED') {
     color = 'secondary';
   }
 


### PR DESCRIPTION
If a build failed the red color will indicate attention already. But for partially completed aka with final paused tasks we should indicate the "call to action" so to speak.